### PR TITLE
UI für KeyMapper

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
@@ -35,7 +35,7 @@ namespace OctoAwesome.Client.Components
             {
                 if (bindings.ContainsKey(id))
                     return;
-                bindings.Add(id, new Binding() {DisplayName = displayName});
+                bindings.Add(id, new Binding() { Id = id, DisplayName = displayName });
             }
 
             /// <summary>

--- a/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
@@ -104,7 +104,6 @@ namespace OctoAwesome.Client.Components
                 }
             }
 
-
             /// <summary>
             /// Sets the DisplayName of a Binding
             /// </summary>
@@ -115,6 +114,40 @@ namespace OctoAwesome.Client.Components
                 Binding binding;
                 if (bindings.TryGetValue(id, out binding))
                     binding.DisplayName = displayName;
+            }
+
+            /// <summary>
+            /// Lädt KeyBindings aus der App.config-Datei und greift, wenn kein Wert vorhanden ist, auf die angegebenen Standardwerte aus.
+            /// </summary>
+            /// <param name="standardKeys"></param>
+            public void LoadFromConfig(Dictionary<string, Keys> standardKeys)
+            {
+                foreach (var id in standardKeys.Keys)
+                {
+                    if (SettingsManager.KeyExists("KeyMapper-" + id))
+                    {
+                        try
+                        {
+                            string val = SettingsManager.Get("KeyMapper-" + id);
+                            Keys key = (Keys)Enum.Parse(typeof(Keys), val);
+                            AddKey(id, key);
+                        }
+                        catch
+                        {
+                            AddKey(id, standardKeys[id]);
+                        }
+                    }
+                    else
+                        AddKey(id, standardKeys[id]);
+                }
+            }
+
+            public List<Binding> GetBindings()
+            {
+                List<Binding> bindings = new List<Binding>();
+                foreach (var binding in Bindings)
+                    bindings.Add(binding.Value);
+                return bindings;
             }
 
 

--- a/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
@@ -25,7 +25,7 @@ namespace OctoAwesome.Client.Components
 
         public bool FlymodeInput { get; set; }
 
-        public bool[] SlotInput { get; private set; } = new bool[20];
+        public bool[] SlotInput { get; private set; } = new bool[10];
 
         public bool SlotLeftInput { get; set; }
 

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using MonoGameUi;
 using OctoAwesome.Client.Components.OctoAwesome.Client.Components;
 using EventArgs = System.EventArgs;
+using System.Collections.Generic;
 
 namespace OctoAwesome.Client
 {
@@ -84,12 +85,73 @@ namespace OctoAwesome.Client
                 graphics.ApplyChanges();
             };
 
-            KeyMapper.RegisterBinding("octoawesome:debugBinding","Debug");
-            KeyMapper.AddKey("octoawesome:debugBinding", Keys.F);
-            KeyMapper.AddAction("octoawesome:debugBinding", type => {Console.WriteLine(type);});
+            SetKeyBindings();
+        }
 
-            KeyMapper.RegisterBinding("octoawesome:forward", "Forward");
-            KeyMapper.AddKey("octoawesome:forward", Keys.W);
+        private void SetKeyBindings()
+        {
+            KeyMapper.RegisterBinding("octoawesome:forward", "Move Forward");
+            KeyMapper.RegisterBinding("octoawesome:left", "Move Left");
+            KeyMapper.RegisterBinding("octoawesome:backward", "Move Backward");
+            KeyMapper.RegisterBinding("octoawesome:right", "Move Right");
+            KeyMapper.RegisterBinding("octoawesome:headup", "Head Up");
+            KeyMapper.RegisterBinding("octoawesome:headdown", "Head Down");
+            KeyMapper.RegisterBinding("octoawesome:headleft", "Head Left");
+            KeyMapper.RegisterBinding("octoawesome:headright", "Head Right");
+            KeyMapper.RegisterBinding("octoawesome:interact", "Interact");
+            KeyMapper.RegisterBinding("octoawesome:apply", "Apply");
+            KeyMapper.RegisterBinding("octoawesome:flymode", "Flymode");
+            KeyMapper.RegisterBinding("octoawesome:jump", "Jump");
+            KeyMapper.RegisterBinding("octoawesome:slot0", "Inventory Slot 0");
+            KeyMapper.RegisterBinding("octoawesome:slot1", "Inventory Slot 1");
+            KeyMapper.RegisterBinding("octoawesome:slot2", "Inventory Slot 2");
+            KeyMapper.RegisterBinding("octoawesome:slot3", "Inventory Slot 3");
+            KeyMapper.RegisterBinding("octoawesome:slot4", "Inventory Slot 4");
+            KeyMapper.RegisterBinding("octoawesome:slot5", "Inventory Slot 5");
+            KeyMapper.RegisterBinding("octoawesome:slot6", "Inventory Slot 6");
+            KeyMapper.RegisterBinding("octoawesome:slot7", "Inventory Slot 7");
+            KeyMapper.RegisterBinding("octoawesome:slot8", "Inventory Slot 8");
+            KeyMapper.RegisterBinding("octoawesome:slot9", "Inventory Slot 9");
+            KeyMapper.RegisterBinding("octoawesome:debug.allblocks", "DEBUG: All Blocktypes in Inventory");
+            KeyMapper.RegisterBinding("octoawesome:debug.control", "DEBUG: Show/Hide Degug Control");
+            KeyMapper.RegisterBinding("octoawesome:inventory", "Inventory");
+            KeyMapper.RegisterBinding("octoawesome:hidecontrols", "Hide all Controls");
+            KeyMapper.RegisterBinding("octoawesome:exit", "Exit");
+            KeyMapper.RegisterBinding("octoawesome:freemouse", "Free/Capture Mouse");
+
+            Dictionary<string, Keys> standardKeys = new Dictionary<string, Keys>()
+            {
+                { "octoawesome:forward", Keys.W },
+                { "octoawesome:left", Keys.A },
+                { "octoawesome:backward", Keys.S },
+                { "octoawesome:right", Keys.D },
+                { "octoawesome:headup", Keys.Up },
+                { "octoawesome:headdown", Keys.Down },
+                { "octoawesome:headleft", Keys.Left },
+                { "octoawesome:headright", Keys.Right },
+                { "octoawesome:interact", Keys.E },
+                { "octoawesome:apply", Keys.Q },
+                { "octoawesome:flymode", Keys.Scroll },
+                { "octoawesome:jump", Keys.Space },
+                { "octoawesome:slot0", Keys.D1 },
+                { "octoawesome:slot1", Keys.D2 },
+                { "octoawesome:slot2", Keys.D3 },
+                { "octoawesome:slot3", Keys.D4 },
+                { "octoawesome:slot4", Keys.D5 },
+                { "octoawesome:slot5", Keys.D6 },
+                { "octoawesome:slot6", Keys.D7 },
+                { "octoawesome:slot7", Keys.D8 },
+                { "octoawesome:slot8", Keys.D9 },
+                { "octoawesome:slot9", Keys.D0 },
+                { "octoawesome:debug.allblocks", Keys.L },
+                { "octoawesome:debug.control", Keys.F10 },
+                { "octoawesome:inventory", Keys.I },
+                { "octoawesome:hidecontrols", Keys.F11 },
+                { "octoawesome:exit", Keys.Escape },
+                { "octoawesome:freemouse", Keys.F12 }
+            };
+
+            KeyMapper.LoadFromConfig(standardKeys);
         }
 
         protected override void OnExiting(object sender, EventArgs args)

--- a/OctoAwesome/OctoAwesome.Client/Screens/BaseScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/BaseScreen.cs
@@ -44,7 +44,7 @@ namespace OctoAwesome.Client.Screens
 
         protected override void OnKeyPress(KeyEventArgs args)
         {
-            if (Manager.CanGoBack && args.Key == Keys.Escape)
+            if (Manager.CanGoBack && args.Key == Keys.Back)
             {
                 args.Handled = true;
                 Manager.NavigateBack();

--- a/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
@@ -68,12 +68,7 @@ namespace OctoAwesome.Client.Screens
 
             Title = Languages.OctoClient.Game;
 
-            //Register Action
-            manager.Game.KeyMapper.AddAction("octoawesome:forward", type =>
-            {
-                if (type == KeyMapper.KeyType.Down) pressedMoveUp = true;
-                else if (type == KeyMapper.KeyType.Up) pressedMoveUp = false;
-            });
+            RegisterKeyActions();
         }
 
         protected override void OnUpdate(GameTime gameTime)
@@ -142,192 +137,166 @@ namespace OctoAwesome.Client.Screens
         private bool pressedHeadDown = false;
         private bool pressedHeadLeft = false;
         private bool pressedHeadRight = false;
-        private bool pressedShift = false;
 
-        protected override void OnKeyDown(KeyEventArgs args)
+        private void RegisterKeyActions()
         {
-            if (!IsActiveScreen) return;
-
-            switch (args.Key)
+            Manager.Game.KeyMapper.AddAction("octoawesome:forward", type =>
             {
-                case Keys.LeftShift:
-                case Keys.RightShift:
-                    pressedShift = true;
-                    args.Handled = true;
-                    break;
-                //case Keys.W:
-                //    pressedMoveUp = true;
-                //    args.Handled = true;
-                //    break;
-                case Keys.A:
-                    pressedMoveLeft = true;
-                    args.Handled = true;
-                    break;
-                case Keys.S:
-                    pressedMoveDown = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D:
-                    pressedMoveRight = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Up:
-                    pressedHeadUp = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Down:
-                    pressedHeadDown = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Left:
-                    pressedHeadLeft = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Right:
-                    pressedHeadRight = true;
-                    args.Handled = true;
-                    break;
-                case Keys.E:
-                    Manager.Player.InteractInput = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Q:
-                    Manager.Player.ApplyInput = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Scroll:
-                    Manager.Player.FlymodeInput = true;
-                    args.Handled = true;
-                    break;
-                case Keys.Space:
-                    Manager.Player.JumpInput = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D1:
-                    Manager.Player.SlotInput[pressedShift ? 10 : 0] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D2:
-                    Manager.Player.SlotInput[pressedShift ? 11 : 1] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D3:
-                    Manager.Player.SlotInput[pressedShift ? 12 : 2] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D4:
-                    Manager.Player.SlotInput[pressedShift ? 13 : 3] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D5:
-                    Manager.Player.SlotInput[pressedShift ? 14 : 4] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D6:
-                    Manager.Player.SlotInput[pressedShift ? 15 : 5] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D7:
-                    Manager.Player.SlotInput[pressedShift ? 16 : 6] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D8:
-                    Manager.Player.SlotInput[pressedShift ? 17 : 7] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D9:
-                    Manager.Player.SlotInput[pressedShift ? 18 : 8] = true;
-                    args.Handled = true;
-                    break;
-                case Keys.D0:
-                    Manager.Player.SlotInput[pressedShift ? 19 : 9] = true;
-                    args.Handled = true;
-                    break;
-            }
-
-            base.OnKeyDown(args);
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedMoveUp = true;
+                else if (type == KeyMapper.KeyType.Up) pressedMoveUp = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:left", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedMoveLeft = true;
+                else if (type == KeyMapper.KeyType.Up) pressedMoveLeft = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:backward", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedMoveDown = true;
+                else if (type == KeyMapper.KeyType.Up) pressedMoveDown = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:right", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedMoveRight = true;
+                else if (type == KeyMapper.KeyType.Up) pressedMoveRight = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:headup", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedHeadUp = true;
+                else if (type == KeyMapper.KeyType.Up) pressedHeadUp = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:headdown", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedHeadDown = true;
+                else if (type == KeyMapper.KeyType.Up) pressedHeadDown = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:headleft", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedHeadLeft = true;
+                else if (type == KeyMapper.KeyType.Up) pressedHeadLeft = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:headright", type =>
+            {
+                if (!IsActiveScreen) return;
+                if (type == KeyMapper.KeyType.Down) pressedHeadRight = true;
+                else if (type == KeyMapper.KeyType.Up) pressedHeadRight = false;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:interact", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.InteractInput = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:apply", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.ApplyInput = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:flymode", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.FlymodeInput = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:jump", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.JumpInput = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot0", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[0] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot1", type =>
+            {
+                if (!IsActiveScreen) return;
+                Manager.Player.SlotInput[1] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot2", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[2] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot3", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[3] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot4", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[4] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot5", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[5] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot6", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[6] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot7", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[7] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot8", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[8] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:slot9", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.SlotInput[9] = true;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:debug.allblocks", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.Player.ActorHost.AllBlocksDebug();
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:debug.control", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                debug.Visible = !debug.Visible;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:inventory", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.NavigateToScreen(new InventoryScreen(Manager));
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:hidecontrols", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                compass.Visible = !compass.Visible;
+                toolbar.Visible = !toolbar.Visible;
+                minimap.Visible = !minimap.Visible;
+                crosshair.Visible = !crosshair.Visible;
+                debug.Visible = !debug.Visible;
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:exit", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                Manager.NavigateToScreen(new MainScreen(Manager));
+            });
+            Manager.Game.KeyMapper.AddAction("octoawesome:freemouse", type =>
+            {
+                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                if (Manager.MouseMode == MouseMode.Captured)
+                    Manager.FreeMouse();
+                else
+                    Manager.CaptureMouse();
+            });
         }
 
-        protected override void OnKeyUp(KeyEventArgs args)
-        {
-            switch (args.Key)
-            {
-                case Keys.LeftShift:
-                case Keys.RightShift:
-                    pressedShift = false;
-                    args.Handled = true;
-                    break;
-                ///case Keys.W:
-                //    pressedMoveUp = false;
-                //    args.Handled = true;
-                //    break;
-                case Keys.A:
-                    pressedMoveLeft = false;
-                    args.Handled = true;
-                    break;
-                case Keys.S:
-                    pressedMoveDown = false;
-                    args.Handled = true;
-                    break;
-                case Keys.D:
-                    pressedMoveRight = false;
-                    args.Handled = true;
-                    break;
-                case Keys.Up:
-                    pressedHeadUp = false;
-                    args.Handled = true;
-                    break;
-                case Keys.Down:
-                    pressedHeadDown = false;
-                    args.Handled = true;
-                    break;
-                case Keys.Left:
-                    pressedHeadLeft = false;
-                    args.Handled = true;
-                    break;
-                case Keys.Right:
-                    pressedHeadRight = false;
-                    args.Handled = true;
-                    break;                
-            }
-
-            base.OnKeyUp(args);
-        }
-
-        protected override void OnKeyPress(KeyEventArgs args)
-        {
-            if (!IsActiveScreen) return;
-
-            switch (args.Key)
-            {
-                case Keys.I:
-                case Keys.Tab:
-                    args.Handled = true;
-                    Manager.NavigateToScreen(new InventoryScreen(Manager));
-                    break;
-                case Keys.F11:
-                    compass.Visible = !compass.Visible;
-                    toolbar.Visible = !toolbar.Visible;
-                    minimap.Visible = !minimap.Visible;
-                    crosshair.Visible = !crosshair.Visible;
-                    break;
-                case Keys.F10:
-                    debug.Visible = !debug.Visible;
-                    break;
-                case Keys.F12:
-                    if (Manager.MouseMode == MouseMode.Captured)
-                        Manager.FreeMouse();
-                    else
-                        Manager.CaptureMouse();
-                    break;
-                case Keys.Escape:
-                    Manager.NavigateToScreen(new MainScreen(Manager));
-                    break;
-                case Keys.L:
-                    Manager.Player.ActorHost.AllBlocksDebug();
-                    break;
-            }
-        }
         #endregion
 
         #region GamePad Input

--- a/OctoAwesome/OctoAwesome.Client/Screens/MessageScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/MessageScreen.cs
@@ -3,45 +3,52 @@ using Microsoft.Xna.Framework.Graphics;
 using MonoGameUi;
 using OctoAwesome.Client.Components;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OctoAwesome.Client.Screens
 {
     internal sealed class MessageScreen : Screen
     {
-        public MessageScreen(ScreenComponent manager, string title, string content, string button = "OK", Action<Control, MouseEventArgs> click = null) : base(manager)
+        public MessageScreen(ScreenComponent manager, string title, string content, string buttonText = "OK", Action<Control, MouseEventArgs> buttonClick = null) : base(manager)
         {
             IsOverlay = true;
+            Background = new BorderBrush(Color.Black * 0.5f);
+            Title = title;
 
             Texture2D panelBackground = manager.Game.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/panel.png", manager.GraphicsDevice);
-            Background = NineTileBrush.FromSingleTexture(panelBackground, 30, 30);
-
-            HorizontalAlignment = HorizontalAlignment.Center;
-            VerticalAlignment = VerticalAlignment.Center;
+            Panel panel = new Panel(manager)
+            {
+                Background = NineTileBrush.FromSingleTexture(panelBackground, 30, 30),
+                Padding = Border.All(20),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            Controls.Add(panel);
 
             StackPanel spanel = new StackPanel(manager);
-            Controls.Add(spanel);
+            panel.Controls.Add(spanel);
 
-            Label headLine = new Label(manager);
-            headLine.Text = title;
-            headLine.Font = Skin.Current.HeadlineFont;
-            headLine.HorizontalAlignment = HorizontalAlignment.Stretch;
+            Label headLine = new Label(manager)
+            {
+                Text = title,
+                Font = Skin.Current.HeadlineFont,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
             spanel.Controls.Add(headLine);
 
-            Label contentLabel = new Label(manager);
-            contentLabel.Text = content;
-            contentLabel.Font = Skin.Current.TextFont;
-            contentLabel.HorizontalAlignment = HorizontalAlignment.Stretch;
+            Label contentLabel = new Label(manager)
+            {
+                Text = content,
+                Font = Skin.Current.TextFont,
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
             spanel.Controls.Add(contentLabel);
 
-            Button closeButton = Button.TextButton(manager, button);
+            Button closeButton = Button.TextButton(manager, buttonText);
             closeButton.HorizontalAlignment = HorizontalAlignment.Stretch;
             closeButton.LeftMouseClick += (s, e) => 
             {
-                if (click != null)
-                    click(s, e);
+                if (buttonClick != null)
+                    buttonClick(s, e);
                 else
                     manager.NavigateBack();
             };

--- a/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
@@ -1,15 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using MonoGameUi;
 using OctoAwesome.Client.Components;
 using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Diagnostics;
 using System.Linq;
-using System.IO;
-using System.Text;
-using System.Windows;
 
 namespace OctoAwesome.Client.Screens
 {
@@ -17,75 +12,106 @@ namespace OctoAwesome.Client.Screens
     {
         private OctoGame game;
         private Button exitButton;
-        private Label rangeTitle, persistenceTitle;
+        private Label rangeTitle;
         private Textbox mapPath;
 
         public OptionsScreen(ScreenComponent manager) : base(manager)
         {
-            game = (OctoGame)manager.Game;
+            game = manager.Game;
             Padding = new Border(0, 0, 0, 0);
 
             Title = Languages.OctoClient.Options;
 
+            Texture2D panelBackground = manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/panel.png", manager.GraphicsDevice);
+
             SetDefaultBackground();
 
-            ////////////////////////////////////////////Settings Stack////////////////////////////////////////////
-            StackPanel settingsStack = new StackPanel(manager);
-            settingsStack.Orientation = Orientation.Vertical;
-            Texture2D panelBackground = manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/panel.png", manager.GraphicsDevice);
-            settingsStack.Background = NineTileBrush.FromSingleTexture(panelBackground, 30, 30);
-            settingsStack.Padding = new Border(20, 20, 20, 20);
-            settingsStack.Width = 500;
-            Controls.Add(settingsStack);
+            TabControl tabs = new TabControl(manager)
+            {
+                Padding = new Border(20, 20, 20, 20),
+                Width = 700,
+                TabPageBackground = NineTileBrush.FromSingleTexture(panelBackground, 30, 30),
+                TabBrush = NineTileBrush.FromSingleTexture(manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/UI/buttonLong_brown.png", manager.GraphicsDevice), 15, 15),
+                TabActiveBrush = NineTileBrush.FromSingleTexture(manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/UI/buttonLong_beige.png", manager.GraphicsDevice), 15, 15),
+            };
+            Controls.Add(tabs);
 
+            #region OptionsPage
+
+            TabPage optionsPage = new TabPage(manager, "Options");
+            tabs.Pages.Add(optionsPage);
+
+            ////////////////////////////////////////////Settings Stack////////////////////////////////////////////
+            StackPanel settingsStack = new StackPanel(manager)
+            {
+                Orientation = Orientation.Vertical,
+                VerticalAlignment = VerticalAlignment.Top,
+                Padding = new Border(20, 20, 20, 20),
+                Width = 650
+            };
+            optionsPage.Controls.Add(settingsStack);
 
             //////////////////////Viewrange//////////////////////
             string viewrange = SettingsManager.Get("Viewrange");
 
-            rangeTitle = new Label(manager);
-            rangeTitle.Text = Languages.OctoClient.Viewrange + ": " + viewrange;
+            rangeTitle = new Label(manager)
+            {
+                Text = Languages.OctoClient.Viewrange + ": " + viewrange
+            };
             settingsStack.Controls.Add(rangeTitle);
 
-            Slider viewrangeSlider = new Slider(manager);
-            viewrangeSlider.HorizontalAlignment = HorizontalAlignment.Stretch;
-            viewrangeSlider.Height = 20;
-            viewrangeSlider.Range = 9;
-            viewrangeSlider.Value = int.Parse(viewrange) - 1;
+            Slider viewrangeSlider = new Slider(manager)
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Height = 20,
+                Range = 9,
+                Value = int.Parse(viewrange) - 1
+            };
             viewrangeSlider.ValueChanged += (value) => SetViewrange(value + 1);
             settingsStack.Controls.Add(viewrangeSlider);
 
 
             //////////////////////Persistence//////////////////////
-            StackPanel persistenceStack = new StackPanel(manager);
-            persistenceStack.Orientation = Orientation.Horizontal;
-            persistenceStack.Margin = new Border(0, 10, 0, 0);
+            StackPanel persistenceStack = new StackPanel(manager)
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Border(0, 10, 0, 0)
+            };
             settingsStack.Controls.Add(persistenceStack);
 
-            persistenceTitle = new Label(manager);
-            persistenceTitle.Text = Languages.OctoClient.DisablePersistence + ":";
+            Label persistenceTitle = new Label(manager)
+            {
+                Text = Languages.OctoClient.DisablePersistence + ":"
+            };
             persistenceStack.Controls.Add(persistenceTitle);
 
-            Checkbox disablePersistence = new Checkbox(manager);
-            disablePersistence.Checked = bool.Parse(SettingsManager.Get("DisablePersistence"));
+            Checkbox disablePersistence = new Checkbox(manager)
+            {
+                Checked = bool.Parse(SettingsManager.Get("DisablePersistence"))
+            };
             disablePersistence.CheckedChanged += (state) => SetPersistence(state);
             persistenceStack.Controls.Add(disablePersistence);
 
             //////////////////////Map Path//////////////////////
-            StackPanel mapPathStack = new StackPanel(manager);
-            mapPathStack.Orientation = Orientation.Horizontal;
-            mapPathStack.Margin = new Border(0, 10, 0, 0);
-            mapPathStack.HorizontalAlignment = HorizontalAlignment.Stretch;
+            StackPanel mapPathStack = new StackPanel(manager)
+            {
+                Orientation = Orientation.Horizontal,
+                Margin = new Border(0, 10, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
             settingsStack.Controls.Add(mapPathStack);
 
-            mapPath = new Textbox(manager);
-            // mapPath.HorizontalAlignment = HorizontalAlignment.Stretch;
-            mapPath.Text = SettingsManager.Get("ChunkRoot");
-            mapPath.Enabled = false;
-            mapPath.Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray);
+            mapPath = new Textbox(manager)
+            {
+                // HorizontalAlignment = HorizontalAlignment.Stretch,
+                Text = SettingsManager.Get("ChunkRoot"),
+                Enabled = false,
+                Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray)
+            };
             mapPathStack.Controls.Add(mapPath);
 
             Button changePath = Button.TextButton(manager, Languages.OctoClient.ChangePath);
-            changePath.Height = 31;
+            changePath.Height = 33;
             changePath.LeftMouseClick += (s, e) => ChangePath();
             mapPathStack.Controls.Add(changePath);
 
@@ -98,6 +124,75 @@ namespace OctoAwesome.Client.Screens
             exitButton.LeftMouseClick += (s, e) => Program.Restart();
             exitButton.Margin = new Border(10, 10, 10, 10);
             Controls.Add(exitButton);
+
+            #endregion
+
+            #region BindingsPage
+
+            TabPage bindingsPage = new TabPage(manager, "Bindings");
+            tabs.Pages.Add(bindingsPage);
+
+            ScrollContainer bindingsScroll = new ScrollContainer(manager);
+            bindingsPage.Controls.Add(bindingsScroll);
+
+            StackPanel bindingsStack = new StackPanel(manager)
+            {
+                Orientation = Orientation.Vertical,
+                Padding = new Border(20, 20, 20, 20),
+                Width = 650
+            };
+            bindingsScroll.Content = bindingsStack;
+
+            //////////////////////////////KeyBindings////////////////////////////////////////////
+            var bindings = game.KeyMapper.GetBindings();
+            foreach (var binding in bindings)
+            {
+                StackPanel bindingStack = new StackPanel(manager)
+                {
+                    Orientation = Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    Height = 35
+                };
+
+                Label lbl = new Label(manager)
+                {
+                    Text = binding.DisplayName,
+                    Width = 500
+                };
+
+                Textbox bindingKeysTextBox = new Textbox(manager)
+                {
+                    Text = binding.Keys.First().ToString(),
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Width = 70,
+                    Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray),
+                    Tag = new object[] { binding.Id, binding.Keys.First() }
+                };
+                bindingKeysTextBox.LostFocus += BindingKeysTextBox_LostFocus;
+
+                bindingStack.Controls.Add(lbl);
+                bindingStack.Controls.Add(bindingKeysTextBox);
+                bindingsStack.Controls.Add(bindingStack);
+            }
+
+            #endregion
+        }
+
+        private void BindingKeysTextBox_LostFocus(Control sender, MonoGameUi.EventArgs args)
+        {
+            object[] data = (object[])sender.Tag;
+            string id = (string)data[0];
+            Keys oldKey = (Keys)data[1];
+
+            string text = ((Textbox)sender).Text;
+            if (text != null && text != "" && Enum.IsDefined(typeof(Keys), text))
+            {
+                Keys newKey = (Keys)Enum.Parse(typeof(Keys), text);
+                game.KeyMapper.RemoveKey(id, oldKey);
+                game.KeyMapper.AddKey(id, newKey);
+                data[1] = newKey;
+                SettingsManager.Set("KeyMapper-" + id, newKey.ToString());
+            }
         }
 
         private void SetViewrange(int newRange)

--- a/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
@@ -157,42 +157,46 @@ namespace OctoAwesome.Client.Screens
                 Label lbl = new Label(manager)
                 {
                     Text = binding.DisplayName,
-                    Width = 500
+                    Width = 480
                 };
 
-                Textbox bindingKeysTextBox = new Textbox(manager)
+                Label bindingKeyLabel = new Label(manager)
                 {
                     Text = binding.Keys.First().ToString(),
                     HorizontalAlignment = HorizontalAlignment.Right,
-                    Width = 70,
+                    Width = 90,
                     Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray),
                     Tag = new object[] { binding.Id, binding.Keys.First() }
                 };
-                bindingKeysTextBox.LostFocus += BindingKeysTextBox_LostFocus;
+                bindingKeyLabel.LeftMouseClick += BindingKeyLabel_LeftMouseClick;
 
                 bindingStack.Controls.Add(lbl);
-                bindingStack.Controls.Add(bindingKeysTextBox);
+                bindingStack.Controls.Add(bindingKeyLabel);
                 bindingsStack.Controls.Add(bindingStack);
             }
 
             #endregion
         }
 
-        private void BindingKeysTextBox_LostFocus(Control sender, MonoGameUi.EventArgs args)
+        private void BindingKeyLabel_LeftMouseClick(Control sender, MouseEventArgs args)
         {
             object[] data = (object[])sender.Tag;
             string id = (string)data[0];
             Keys oldKey = (Keys)data[1];
 
-            string text = ((Textbox)sender).Text;
-            if (text != null && text != "" && Enum.IsDefined(typeof(Keys), text))
+            Label lbl = (Label)sender;
+
+            MessageScreen screen = new MessageScreen((ScreenComponent)Manager, "Press key...", "", "Cancel");
+            screen.KeyDown += (s, a) =>
             {
-                Keys newKey = (Keys)Enum.Parse(typeof(Keys), text);
                 game.KeyMapper.RemoveKey(id, oldKey);
-                game.KeyMapper.AddKey(id, newKey);
-                data[1] = newKey;
-                SettingsManager.Set("KeyMapper-" + id, newKey.ToString());
-            }
+                game.KeyMapper.AddKey(id, a.Key);
+                data[1] = a.Key;
+                SettingsManager.Set("KeyMapper-" + id, a.Key.ToString());
+                lbl.Text = a.Key.ToString();
+                Manager.NavigateBack();
+            };
+            Manager.NavigateToScreen(screen);
         }
 
         private void SetViewrange(int newRange)

--- a/OctoAwesome/OctoAwesome/SettingsManager.cs
+++ b/OctoAwesome/OctoAwesome/SettingsManager.cs
@@ -40,7 +40,10 @@ namespace OctoAwesome
         public static void Set(string key, string value)
         {
             var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
-            config.AppSettings.Settings[key].Value = value;
+            if (config.AppSettings.Settings.AllKeys.Contains(key))
+                config.AppSettings.Settings[key].Value = value;
+            else
+                config.AppSettings.Settings.Add(key, value);
             config.Save(ConfigurationSaveMode.Modified, false);
         }
     }


### PR DESCRIPTION
* Alle Tasten aus den `OnKeyDown/Up/Press` Methoden in den `KeyMapper` umgezogen.
* Den `KeyMapper` um ein paar kleine Funktionalitäten (Laden von Standardwerten und aus der Konfiguration, alle Bindings zurückgeben) erweitert.
* `OptionsScreen` um ein `TabControl` erweitert, zwei Tabs (Options, Bindings) eingeführt.
* Simples UI für das Zuweisen von Keys zu Bindings.

**ABER:**
* Es geht bis jetzt nur ein Key pro Binding

Außerdem möchte ich noch von @fnawratil wissen, ob ihm das so passt, ist ja schließlich sein KeyMapper.

**EDIT:** Ich habe erst jetzt bemerkt, dass es zu Konflikten mit der Escape Taste kommt (`BaseScreen` und `GameScreen`). Daher navigiert jetzt Backspace zum letzten Screen, nicht mehr Esc (aber noch nicht über den KeyMapper anpassbar). Esc kehrt wie gewohnt zum `MainScreen` zurück.