### PR TITLE
Feature/settings manager

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/KeyMapper.cs
@@ -128,7 +128,7 @@ namespace OctoAwesome.Client.Components
                     {
                         try
                         {
-                            string val = SettingsManager.Get("KeyMapper-" + id);
+                            string val = SettingsManager.Get<string>("KeyMapper-" + id);
                             Keys key = (Keys)Enum.Parse(typeof(Keys), val);
                             AddKey(id, key);
                         }

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -43,7 +43,7 @@ namespace OctoAwesome.Client
             graphics = new GraphicsDeviceManager(this);
 
             int width;
-            if (int.TryParse(SettingsManager.Get("Width"), out width))
+            if (int.TryParse(SettingsManager.Get<string>("Width"), out width))
             {
                 if (width < 1)
                     throw new NotSupportedException("Width in app.config darf nicht kleiner 1 sein");
@@ -54,7 +54,7 @@ namespace OctoAwesome.Client
                 graphics.PreferredBackBufferWidth = 1080;
 
             int height;
-            if (int.TryParse(SettingsManager.Get("Height"), out height))
+            if (int.TryParse(SettingsManager.Get<string>("Height"), out height))
             {
                 if (height < 1)
                     throw new NotSupportedException("Height in app.config darf nicht kleiner 1 sein");
@@ -72,11 +72,11 @@ namespace OctoAwesome.Client
             TargetElapsedTime = new TimeSpan(0, 0, 0, 0, 15);
 
             bool enablefullscreen;
-            if (bool.TryParse(SettingsManager.Get("EnableFullscreen"), out enablefullscreen) && enablefullscreen)
+            if (bool.TryParse(SettingsManager.Get<string>("EnableFullscreen"), out enablefullscreen) && enablefullscreen)
                 Fullscreen();
 
             int viewrange;
-            if (int.TryParse(SettingsManager.Get("Viewrange"), out viewrange))
+            if (int.TryParse(SettingsManager.Get<string>("Viewrange"), out viewrange))
             {
                 if (viewrange < 1)
                     throw new NotSupportedException("Viewrange in app.config darf nicht kleiner 1 sein");

--- a/OctoAwesome/OctoAwesome.Client/Screens/LoadScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/LoadScreen.cs
@@ -131,10 +131,10 @@ namespace OctoAwesome.Client.Screens
             if (levelList.Items.Count >= 1)
                 levelList.SelectedItem = levelList.Items[0];
 
-            if (SettingsManager.KeyExists("LastUniverse") && SettingsManager.Get("LastUniverse") != null
-                && SettingsManager.Get("LastUniverse") != "")
+            if (SettingsManager.KeyExists("LastUniverse") && SettingsManager.Get<string>("LastUniverse") != null
+                && SettingsManager.Get<string>("LastUniverse") != "")
             {
-                levelList.SelectedItem = levelList.Items.First(u => u.Id == Guid.Parse(SettingsManager.Get("LastUniverse")));
+                levelList.SelectedItem = levelList.Items.First(u => u.Id == Guid.Parse(SettingsManager.Get<string>("LastUniverse")));
             }
         }
 

--- a/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/OptionsScreen.cs
@@ -52,7 +52,7 @@ namespace OctoAwesome.Client.Screens
             optionsPage.Controls.Add(settingsStack);
 
             //////////////////////Viewrange//////////////////////
-            string viewrange = SettingsManager.Get("Viewrange");
+            string viewrange = SettingsManager.Get<string>("Viewrange");
 
             rangeTitle = new Label(manager)
             {
@@ -87,7 +87,7 @@ namespace OctoAwesome.Client.Screens
 
             Checkbox disablePersistence = new Checkbox(manager)
             {
-                Checked = bool.Parse(SettingsManager.Get("DisablePersistence")),
+                Checked = bool.Parse(SettingsManager.Get<string>("DisablePersistence")),
                 HookBrush = new TextureBrush(manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/UI/iconCheck_brown.png", manager.GraphicsDevice), TextureBrushMode.Stretch),
             };
             disablePersistence.CheckedChanged += (state) => SetPersistence(state);
@@ -104,7 +104,7 @@ namespace OctoAwesome.Client.Screens
 
             mapPath = new Textbox(manager)
             {
-                Text = SettingsManager.Get("ChunkRoot"),
+                Text = SettingsManager.Get<string>("ChunkRoot"),
                 Enabled = false,
                 HorizontalAlignment = HorizontalAlignment.Stretch,              
                 Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray)
@@ -133,7 +133,7 @@ namespace OctoAwesome.Client.Screens
 
             Checkbox enableFullscreen = new Checkbox(manager)
             {
-                Checked = bool.Parse(SettingsManager.Get("EnableFullscreen")),
+                Checked = bool.Parse(SettingsManager.Get<string>("EnableFullscreen")),
                 HookBrush = new TextureBrush(manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/UI/iconCheck_brown.png", manager.GraphicsDevice), TextureBrushMode.Stretch),
             };
             enableFullscreen.CheckedChanged += (state) => SetFullscreen(state);
@@ -155,7 +155,7 @@ namespace OctoAwesome.Client.Screens
 
             Textbox resolutionWidthTextbox = new Textbox(manager)
             {
-                Text = SettingsManager.Get("Width"),
+                Text = SettingsManager.Get<string>("Width"),
                 Width = 50,
                 Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray)
             };
@@ -170,7 +170,7 @@ namespace OctoAwesome.Client.Screens
 
             Textbox resolutionHeightTextbox = new Textbox(manager)
             {
-                Text = SettingsManager.Get("Height"),
+                Text = SettingsManager.Get<string>("Height"),
                 Width = 50,
                 Background = new BorderBrush(Color.LightGray, LineType.Solid, Color.Gray)
             };
@@ -296,7 +296,7 @@ namespace OctoAwesome.Client.Screens
         private void ChangePath()
         {
             System.Windows.Forms.FolderBrowserDialog folderBrowser = new System.Windows.Forms.FolderBrowserDialog();
-            folderBrowser.SelectedPath = SettingsManager.Get("ChunkRoot");
+            folderBrowser.SelectedPath = SettingsManager.Get<string>("ChunkRoot");
 
             if (folderBrowser.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {

--- a/OctoAwesome/OctoAwesome.Runtime/DiskPersistenceManager.cs
+++ b/OctoAwesome/OctoAwesome.Runtime/DiskPersistenceManager.cs
@@ -28,7 +28,7 @@ namespace OctoAwesome.Runtime
             if (root != null)
                 return root.FullName;
 
-            string appconfig = SettingsManager.Get("ChunkRoot");
+            string appconfig = SettingsManager.Get<string>("ChunkRoot");
             if (!string.IsNullOrEmpty(appconfig))
             {
                 root = new DirectoryInfo(appconfig);

--- a/OctoAwesome/OctoAwesome.Runtime/ResourceManager.cs
+++ b/OctoAwesome/OctoAwesome.Runtime/ResourceManager.cs
@@ -56,7 +56,7 @@ namespace OctoAwesome.Runtime
 
             planets = new Dictionary<int, IPlanet>();
 
-            bool.TryParse(SettingsManager.Get("DisablePersistence"), out disablePersistence);
+            bool.TryParse(SettingsManager.Get<string>("DisablePersistence"), out disablePersistence);
         }
 
         /// <summary>

--- a/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
+++ b/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OctoAwesome.Tests
@@ -9,8 +11,35 @@ namespace OctoAwesome.Tests
         [TestMethod]
         public void ReadWrite()
         {
+            SettingsManager.DEBUG = true;
+
+            string[] testArray = new string[] {"foo", "bar"};
+            SettingsManager.Set("foo", testArray);
+            
+            string[] newArray = SettingsManager.GetArray<string>("foo");
+
+            Assert.IsTrue(testArray.SequenceEqual(newArray));
+
+
+            int[] testArrayInt = new int[] { 3,5,333,456,3457};
+            SettingsManager.Set("fooInt", testArrayInt);
+
+            int[] newArrayInt = SettingsManager.GetArray<int>("fooInt");
+
+            Assert.IsTrue(testArray.SequenceEqual(newArray));
+
+
+            bool[] testArrayBool = new bool[] { true, false};
+            SettingsManager.Set("fooBool", testArrayBool);
+
+            bool[] newArrayBool = SettingsManager.GetArray<bool>("fooBool");
+
+            Assert.IsTrue(testArray.SequenceEqual(newArray));
+
+
             String inputString = "randomStringWith§$%&/()=Charakters";
             SettingsManager.Set("inputString", inputString);
+
 
             Assert.AreEqual(inputString, SettingsManager.Get<string>("inputString"));
 
@@ -25,6 +54,7 @@ namespace OctoAwesome.Tests
             SettingsManager.Set("inputBool", inputBool);
 
             Assert.AreEqual(inputBool, SettingsManager.Get<bool>("inputBool"));
+
 
 
         }

--- a/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
+++ b/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OctoAwesome.Tests
+{
+    [TestClass]
+    public class SettingsManagerTests
+    {
+        [TestMethod]
+        public void ReadWrite()
+        {
+            String inputString = "randomStringWith§$%&/()=Charakters";
+            SettingsManager.Set("inputString", inputString);
+
+            Assert.AreEqual(inputString, SettingsManager.Get<string>("inputString"));
+
+
+            int inputInt = new Random().Next();
+            SettingsManager.Set("inputInt", inputInt);
+
+            Assert.AreEqual(inputInt, SettingsManager.Get<int>("inputInt"));
+
+
+            bool inputBool = true;
+            SettingsManager.Set("inputBool", inputBool);
+
+            Assert.AreEqual(inputBool, SettingsManager.Get<bool>("inputBool"));
+
+
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome/SettingsManager.cs
+++ b/OctoAwesome/OctoAwesome/SettingsManager.cs
@@ -1,6 +1,9 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace OctoAwesome
 {
@@ -8,18 +11,34 @@ namespace OctoAwesome
     /// Verwaltet die Anwendungseinstellungen.
     /// TODO: In den Client verschieben
     /// </summary>
+    
     public static class SettingsManager
     {
+
+        
+
+      
+
         /// <summary>
         /// Gibt den Wert einer Einstellung zurück.
         /// </summary>
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <returns>Der Wert der Einstellung.</returns>
-        public static string Get(string key)
-        {
-            var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
-            return config.AppSettings.Settings[key].Value;
+        public static T Get<T>(string key) {
+
+
+            
+            // var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+
+            var config = Configuration;
+
+            var valueConfig = config.AppSettings.Settings[key].Value;
+
+            return (T) Convert.ChangeType(valueConfig, typeof(T));
+
+
         }
+        
 
         /// <summary>
         /// Überprüft, ob die angegebene Einstellung existeiert.
@@ -28,7 +47,10 @@ namespace OctoAwesome
         /// <returns></returns>
         public static bool KeyExists(string key)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+            // var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+
+            var config = Configuration;
+
             return config.AppSettings.Settings.AllKeys.Contains(key);
         }
 
@@ -37,14 +59,48 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <param name="value">Der Wert der Einstellung.</param>
+
         public static void Set(string key, string value)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+
+
+            
+
+            var config = Configuration;
+
+
             if (config.AppSettings.Settings.AllKeys.Contains(key))
                 config.AppSettings.Settings[key].Value = value;
             else
                 config.AppSettings.Settings.Add(key, value);
             config.Save(ConfigurationSaveMode.Modified, false);
+        }
+
+        public static void Set(string key, int value)
+        {
+            Set(key, Convert.ToString(value));
+        }
+
+        public static void Set(string key, bool value)
+        {
+            Set(key, Convert.ToString(value));
+        }
+
+        private static Configuration Configuration
+        {
+            get
+            {
+                //StackOverflow: http://stackoverflow.com/questions/1083927/configurationmanager-openexeconfiguration-loads-the-wrong-file
+
+                // ExeConfigurationFileMap map = new ExeConfigurationFileMap { ExeConfigFilename = "EXECONFIG_PATH" };
+                // Configuration config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
+
+                var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+
+
+                Console.WriteLine(config.FilePath);
+                return config;
+            }
         }
     }
 }

--- a/OctoAwesome/OctoAwesome/SettingsManager.cs
+++ b/OctoAwesome/OctoAwesome/SettingsManager.cs
@@ -11,23 +11,22 @@ namespace OctoAwesome
     /// Verwaltet die Anwendungseinstellungen.
     /// TODO: In den Client verschieben
     /// </summary>
-    
     public static class SettingsManager
     {
+        /// <summary>
+        /// Bei UnitTests ist Assembly.GetEntryAssembly null, Gründe dazu gibts auf StackOverflow.
+        /// Um Schmerzen zu vermeiden wurde eine Variable eingeführt, die unabhängig testet.
+        /// </summary>
+        public static bool DEBUG = false;
 
-        
-
-      
 
         /// <summary>
         /// Gibt den Wert einer Einstellung zurück.
         /// </summary>
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <returns>Der Wert der Einstellung.</returns>
-        public static T Get<T>(string key) {
-
-
-            
+        public static T Get<T>(string key)
+        {
             // var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
 
             var config = Configuration;
@@ -35,10 +34,22 @@ namespace OctoAwesome
             var valueConfig = config.AppSettings.Settings[key].Value;
 
             return (T) Convert.ChangeType(valueConfig, typeof(T));
-
-
         }
-        
+
+        /// <summary>
+        /// Gibt das Array einer Einstellung zurück
+        /// </summary>
+        /// <typeparam name="T">Art der Einstellung</typeparam>
+        /// <param name="key">Schlüssel der Einstellung</param>
+        /// <returns>Das Array der Einstellung</returns>
+        public static T[] GetArray<T>(string key)
+        {
+            var config = Configuration;
+
+            var valueConfig = config.AppSettings.Settings[key].Value;
+
+            return DeserializeArray<T>(valueConfig);
+        }
 
         /// <summary>
         /// Überprüft, ob die angegebene Einstellung existeiert.
@@ -59,13 +70,8 @@ namespace OctoAwesome
         /// </summary>
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <param name="value">Der Wert der Einstellung.</param>
-
         public static void Set(string key, string value)
         {
-
-
-            
-
             var config = Configuration;
 
 
@@ -76,14 +82,72 @@ namespace OctoAwesome
             config.Save(ConfigurationSaveMode.Modified, false);
         }
 
+        /// <summary>
+        /// Setzt den Wert einer Eigenschaft.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="value">Der Wert der Einstellung.</param>
         public static void Set(string key, int value)
         {
             Set(key, Convert.ToString(value));
         }
 
+        /// <summary>
+        /// Setzt den Wert einer Eigenschaft.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="value">Der Wert der Einstellung.</param>
         public static void Set(string key, bool value)
         {
             Set(key, Convert.ToString(value));
+        }
+
+        /// <summary>
+        /// Setzt den Wert einer Eigenschaft.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="values">Der Wert der Einstellung.</param>
+        public static void Set(string key, string[] values)
+        {
+            /* Wir bauen das Array in eine Art serialisierten String um.
+             * Wenn eine Zeichenkette, die wir aus den Einstellugen lesen mit einer
+             * eckigen Klammer anfängt, ist es ein Array.
+             * [value1, value2, value3]
+             * 
+             */
+
+            string writeString = "[" + String.Join(",", values) + "]";
+            Set(key, writeString);
+        }
+
+        /// <summary>
+        /// Setzt den Wert einer Eigenschaft.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="values">Der Wert der Einstellung.</param>
+        public static void Set(string key, int[] values)
+        {
+            string[] strValues = new string[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                strValues[i] = Convert.ToString(values[i]);
+            }
+            Set(key, strValues);
+        }
+
+        /// <summary>
+        /// Setzt den Wert einer Eigenschaft.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="values">Der Wert der Einstellung.</param>
+        public static void Set(string key, bool[] values)
+        {
+            string[] stringValues = new string[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                stringValues[i] = Convert.ToString(values[i]);
+            }
+            Set(key, stringValues);
         }
 
         private static Configuration Configuration
@@ -92,15 +156,42 @@ namespace OctoAwesome
             {
                 //StackOverflow: http://stackoverflow.com/questions/1083927/configurationmanager-openexeconfiguration-loads-the-wrong-file
 
-                // ExeConfigurationFileMap map = new ExeConfigurationFileMap { ExeConfigFilename = "EXECONFIG_PATH" };
-                // Configuration config = ConfigurationManager.OpenMappedExeConfiguration(map, ConfigurationUserLevel.None);
+                Configuration config;
 
-                var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
-
+                if (DEBUG)
+                {
+                    ExeConfigurationFileMap map = new ExeConfigurationFileMap {ExeConfigFilename = "EXECONFIG_PATH"};
+                    config = ConfigurationManager.OpenMappedExeConfiguration(map,
+                        ConfigurationUserLevel.None);
+                }
+                else
+                {
+                    config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+                }
 
                 Console.WriteLine(config.FilePath);
                 return config;
             }
+        }
+
+        private static T[] DeserializeArray<T>(string arrayString)
+        {
+
+            // Wir müssten, um beide Klammern zu entfernen, - 3 rechnen. Ich lasse die letzte Klammer stellvertretend für das Komma, was folgen würde, stehen.
+            // Das wird in der for-Schleife auseinander gepflückt.
+
+
+            arrayString = arrayString.Substring(1, arrayString.Length - 2 /*- 1*/);
+
+            string[] partsString = arrayString.Split(',');
+            T[] tArray = new T[partsString.Length];
+            for (int i = 0; i < partsString.Length; i++)
+            {
+                tArray[i] = (T) Convert.ChangeType(partsString[i], typeof(T));
+            }
+
+
+            return tArray;
         }
     }
 }


### PR DESCRIPTION
Habe den SettingsManager aufgebohrt. Er kann für den Anfang bool, int und strings und deren Arrays speichern. Ich habe die Spieledateien soweit modifiziert, dass sie mit dem generischen Getter umgehen können, aber noch **nicht** überprüft, wo optimiert werden kann. 

Wenn ein Wert geladen werden soll und dieser Wert nicht existiert oder nicht das Format hat, was der User gerne möchte, knallt es. Ich denke, dass man das so lassen kann.

Desweiteren sollte man drüber nachdenken, wo man das SettingsFile hinlegt. Im Moment kann jede Extension und so in die Config-Files schreiben, da das Config-File über den **EntryPoint** definiert ist. Der EntryPoint ist immer OctoAwesome.Client, wenn ich richtig liege. 