### PR TITLE
Crew per JS im Wiki

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Assets/OctoAwesome.Client/Crew/crew.xml
+++ b/OctoAwesome/OctoAwesome.Client/Assets/OctoAwesome.Client/Crew/crew.xml
@@ -7,6 +7,7 @@
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Anteru</Username>
@@ -16,7 +17,12 @@
       <Achievements>EmailJoker</Achievements>
       <Achievements>Livegast</Achievements>
       <Achievements>Streamer</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Blog" Url="https://anteru.net/" />
+      <Link Title="OctoAwesome Blogeintrag" Url="https://anteru.net/2015/08/06/2847/" />      
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>bobstriker</Username>
@@ -26,6 +32,10 @@
       <Achievements>Streamer</Achievements>
       <Achievements>Livegast</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Youtube Channel" Url="https://www.youtube.com/c/tomwendel" />
+      <Link Title="Patreon" Url="https://www.patreon.com/bobstriker" />
+    </Links>
     <PictureFilename>./Assets/OctoAwesome.Client/Crew/bobstriker.png</PictureFilename>
   </CrewMember>
   <CrewMember>
@@ -36,6 +46,9 @@
       <Achievements>Patron</Achievements>
       <Achievements>HardwareDealer</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Youtube Channel" Url="https://www.youtube.com/channel/UCihFcS0QvNaVY84-hFmNE3A" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>hendifw</Username>
@@ -43,7 +56,10 @@
     <Description>Der Mann für die Registrierungs Webseite, ist seit der 20 Folge mit dabei und Streamt in Zukunft die Coolen ASP.NET OctoAwesome Sachen.</Description>
     <AchievementList>
       <Achievements>Streamer</Achievements>
+      <Achievements>Contributor</Achievements>
+      <Achievements>DatenbankFreigeschaltet</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Dennis</Username>
@@ -52,6 +68,7 @@
     <AchievementList>
       <Achievements>Patron</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>jvbsl</Username>
@@ -61,7 +78,12 @@
       <Achievements>Livegast</Achievements>
       <Achievements>Streamer</Achievements>
       <Achievements>Tools</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Livecoding.tv" Url="https://www.livecoding.tv/jvbsl/" />
+      <Link Title="GitHub-Projekte" Url="https://github.com/jvbsl/" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>Juergen</Username>
@@ -70,6 +92,7 @@
     <AchievementList>
       <Achievements>Patron</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Kapu</Username>
@@ -78,6 +101,9 @@
     <AchievementList>
       <Achievements>Musik</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Youtube Channel" Url="https://www.youtube.com/user/Raidon90" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>Lassi</Username>
@@ -85,7 +111,11 @@
     <Description>Lassi war der erste Stargast im Octo-Universum und hat recht früh im Spiel dafür gesorgt, dass die Physik die richtigen Wege geht. Das ganze Trägheits- und Beschleunigungsthema war noch nie so meins. Wie wir alle wissen, hat er zuletzt seinen Elektrotechniker abgeschlossen, studiert aber tapfer weiter. Ich kann nur hoffen, dass es ein Master mit Schwerpunkt Animations-Physik ist.</Description>
     <AchievementList>
       <Achievements>Livegast</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="GitHub-Projekte" Url="https://github.com/CsharpLassi" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>macx</Username>
@@ -94,16 +124,23 @@
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>manuelhu</Username>
     <Alias>Manuel</Alias>
-    <Description>Von Manuel habe ich anfangs reichlich Feedback per YouTube-Kommentaren bekommen. Später dann per Email, bis er letztendlich durch die Livestreams zur rettenden Fee im Wiki wurde. Ohne ihn hätten wir hier keinen Episoden-Guide und auch mein Octo-Timer stammt aus seinem Compiler.</Description>
+    <Description>Von Manuel habe ich anfangs reichlich Feedback per YouTube-Kommentaren bekommen. Später dann per Email, bis er letztendlich durch die Livestreams zur rettenden Fee im Wiki wurde. Ohne ihn hätten wir hier keinen Episoden-Guide und auch mein Octo-Timer stammt aus seinem Compiler. Er kümmert sich außerdem noch um usere Dokumentation auf doc.octoawesome.net.</Description>
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
       <Achievements>Tools</Achievements>
       <Achievements>WikiAdmin</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="GitHub-Projekte" Url="https://github.com/ManuelHu" />
+      <Link Title="OctoReminder" Url="https://github.com/ManuelHu/OctoReminder" />
+      <Link Title="Website" Url="https://www.manuelhu.de/" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>Marcus_Aurelius</Username>
@@ -112,7 +149,9 @@
     <AchievementList>
       <Achievements>WikiAdmin</Achievements>
       <Achievements>Streamer</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>MarkusK</Username>
@@ -122,6 +161,7 @@
       <Achievements>EmailJoker</Achievements>
       <Achievements>Patron</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Mrsfuckingsunshine</Username>
@@ -131,6 +171,9 @@
       <Achievements>Livegast</Achievements>
       <Achievements>Grafik</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Web" Url="http://www.alineimwunderland.de/" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>patteki</Username>
@@ -140,6 +183,11 @@
       <Achievements>Livegast</Achievements>
       <Achievements>Streamer</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Livecoding.tv" Url="https://www.livecoding.tv/patteki/" />
+      <Link Title="Youtube" Url="https://www.youtube.com/user/Patteminecraft" />
+      <Link Title="Twitch" Url="http://www.twitch.tv/patteki" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>Paul</Username>
@@ -147,7 +195,9 @@
     <Description>Paul kenne ich noch aus den guten alten Microsoft Student Partner Zeiten. Er ist Software Entwickler im Raum Berlin und hat uns einzig und alleine ins Chaos gestürzt. Ihn hatten wir im Stream zur Performance- und Speicher-Optimierung. Mit großem Erfolg hat er Octo umgekrempelt.</Description>
     <AchievementList>
       <Achievements>Livegast</Achievements>
+      <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Ralf</Username>
@@ -156,15 +206,19 @@
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Rave1000</Username>
-    <Alias>Rave1000</Alias>
+    <Alias>fnawratil / Fabian</Alias>
     <Description>Immer am Start, immer dabei mit jeder Menge Verbesserungen bei Octo und MonoGameUI.</Description>
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
       <Achievements>Contributor</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="GitHub" Url="https://github.com/fnawratil" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>Redwork</Username>
@@ -173,6 +227,7 @@
     <AchievementList>
       <Achievements>EmailJoker</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>SomaFM</Username>
@@ -181,6 +236,9 @@
     <AchievementList>
       <Achievements>Tools</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="Secret Agent" Url="http://somafm.com/secretagent/" />
+    </Links>
   </CrewMember>
   <CrewMember>
     <Username>susch19</Username>
@@ -190,6 +248,7 @@
       <Achievements>EmailJoker</Achievements>
       <Achievements>Streamer</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Ulrich</Username>
@@ -198,6 +257,7 @@
     <AchievementList>
       <Achievements>Patron</Achievements>
     </AchievementList>
+    <Links></Links>
   </CrewMember>
   <CrewMember>
     <Username>Vengarioth</Username>
@@ -207,5 +267,8 @@
       <Achievements>Livegast</Achievements>
       <Achievements>Patron</Achievements>
     </AchievementList>
+    <Links>
+      <Link Title="GitHub" Url="https://github.com/Vengarioth" />
+    </Links>
   </CrewMember>
 </ArrayOfCrewMember>

--- a/OctoAwesome/OctoAwesome.Client/CrewMember.cs
+++ b/OctoAwesome/OctoAwesome.Client/CrewMember.cs
@@ -19,7 +19,8 @@ namespace OctoAwesome.Client
             Contributor,
             Musik,
             Grafik,
-            WikiAdmin
+            WikiAdmin,
+            DatenbankFreigeschaltet
         };
 
         public string Username { get; set; }
@@ -30,6 +31,8 @@ namespace OctoAwesome.Client
         public List<Achievements> AchievementList { get; set; }
 
         public string PictureFilename { get; set; }
+        
+        public List<Link> Links { get; set; }
 
         public CrewMember() { }
 
@@ -46,6 +49,20 @@ namespace OctoAwesome.Client
 
                 return new List<CrewMember>();                
             }
+        }
+
+        public override string ToString()
+        {
+            return Username;
+        }
+
+        public class Link
+        {
+            [XmlAttribute]
+            public string Title { get; set; }
+
+            [XmlAttribute]
+            public string Url { get; set; }
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.Client/CrewMember.cs
+++ b/OctoAwesome/OctoAwesome.Client/CrewMember.cs
@@ -24,6 +24,7 @@ namespace OctoAwesome.Client
         };
 
         public string Username { get; set; }
+
         public string Alias { get; set; }
 
         public string Description { get; set; }

--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.Designer.cs
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.Designer.cs
@@ -268,6 +268,15 @@ namespace OctoAwesome.Client.Languages {
         }
         
         /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Links ähnelt.
+        /// </summary>
+        internal static string Links {
+            get {
+                return ResourceManager.GetString("Links", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Sucht eine lokalisierte Zeichenfolge, die Dirty/Loaded ChunkColumn ähnelt.
         /// </summary>
         internal static string LoadedChunks {

--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.de.resx
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.de.resx
@@ -237,4 +237,7 @@
   <data name="KeyBindings" xml:space="preserve">
     <value>Tastaturbelegung</value>
   </data>
+  <data name="Links" xml:space="preserve">
+    <value>Links</value>
+  </data>
 </root>

--- a/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.resx
+++ b/OctoAwesome/OctoAwesome.Client/Languages/OctoClient.resx
@@ -237,4 +237,7 @@
   <data name="KeyBindings" xml:space="preserve">
     <value>Key Bindings</value>
   </data>
+  <data name="Links" xml:space="preserve">
+    <value>Links</value>
+  </data>
 </root>

--- a/OctoAwesome/OctoAwesome.Client/Screens/CrewMemberScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/CrewMemberScreen.cs
@@ -6,6 +6,7 @@ using MonoGameUi;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using OctoAwesome.Client.Components;
+using System.Diagnostics;
 
 namespace OctoAwesome.Client.Screens
 {
@@ -18,7 +19,7 @@ namespace OctoAwesome.Client.Screens
 
             Title = Languages.OctoClient.CreditsCrew + ": " + member.Username;
 
-            SpriteFont boldFont = manager.Content.Load<SpriteFont>("BoldFont");            
+            SpriteFont boldFont = manager.Content.Load<SpriteFont>("BoldFont");
 
             Padding = new Border(0, 0, 0, 0);
 
@@ -28,21 +29,11 @@ namespace OctoAwesome.Client.Screens
             Texture2D panelBackground = manager.Content.LoadTexture2DFromFile("./Assets/OctoAwesome.Client/panel.png", manager.GraphicsDevice);
             Panel panel = new Panel(manager)
             {
-                MaxWidth = 750,
+                MaxWidth = 750,                
                 Background = NineTileBrush.FromSingleTexture(panelBackground, 30, 30),
                 Padding = new Border(15, 15, 15, 15),
             };
-
             Controls.Add(panel);
-
-            //The Vertical Stack - Split the Panel in half Vertical
-            StackPanel verticalStack = new StackPanel(manager)
-            {
-                VerticalAlignment = VerticalAlignment.Stretch,
-                HorizontalAlignment = HorizontalAlignment.Stretch,
-                Orientation = Orientation.Vertical,
-            };
-            // panel.Controls.Add(verticalStack);
 
             //The Main Stack - Split the Panel in half Horizontal
             StackPanel horizontalStack = new StackPanel(manager)
@@ -93,34 +84,53 @@ namespace OctoAwesome.Client.Screens
             textStack.Controls.Add(alias);
 
             //Achievements
-            string achievementString = "";
+            string achievementString = string.Join(", ", member.AchievementList.Select(a => a.ToString()));
 
-            foreach (CrewMember.Achievements achievement in member.AchievementList)
+            StackPanel achievementStack = new StackPanel(manager)
             {
-                achievementString += " " + achievement.ToString();
-                if (member.AchievementList.IndexOf(achievement) != member.AchievementList.Count - 1) achievementString += ", ";
-            }
-            StackPanel achievementStack = new StackPanel(manager);
-            achievementStack.VerticalAlignment = VerticalAlignment.Top;
-            achievementStack.HorizontalAlignment = HorizontalAlignment.Left;
-            achievementStack.Orientation = Orientation.Horizontal;
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Orientation = Orientation.Horizontal,
+            };
             textStack.Controls.Add(achievementStack);
 
             Label achievementsTitle = new Label(manager) { Text = Languages.OctoClient.Achievements + ": ", Font = boldFont, HorizontalAlignment = HorizontalAlignment.Left };
-
-            Label achievements = new Label(manager) { Text = achievementString, HorizontalAlignment = HorizontalAlignment.Left };
-
             achievementStack.Controls.Add(achievementsTitle);
+            Label achievements = new Label(manager) { Text = achievementString, HorizontalAlignment = HorizontalAlignment.Left };            
             achievementStack.Controls.Add(achievements);
 
-            Panel DescriptionPanel = new Panel(manager)
+            // Links
+            string linkString = string.Join(", ", member.Links.Select(a => a.Title));
+
+            StackPanel linkStack = new StackPanel(manager)
+            {
+                VerticalAlignment = VerticalAlignment.Top,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Orientation = Orientation.Horizontal,
+            };
+            textStack.Controls.Add(linkStack);
+
+            Label linkTitle = new Label(manager) { Text = Languages.OctoClient.Links + ": ", Font = boldFont, HorizontalAlignment = HorizontalAlignment.Left };
+            linkStack.Controls.Add(linkTitle);
+
+            foreach (var link in member.Links)
+            {                
+                if (CheckHttpUrl(link.Url))
+                {
+                    Button linkButton = Button.TextButton(manager, link.Title);
+                    linkButton.LeftMouseClick += (s, e) => Process.Start(link.Url);
+                    linkStack.Controls.Add(linkButton);
+                }
+            }
+
+            Panel descriptionPanel = new Panel(manager)
             {
                 VerticalAlignment = VerticalAlignment.Stretch,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
             };
-            textStack.Controls.Add(DescriptionPanel);
+            textStack.Controls.Add(descriptionPanel);
 
-            Label Description = new Label(manager)
+            Label description = new Label(manager)
             {
                 Text = member.Description,
                 WordWrap = true,
@@ -128,13 +138,17 @@ namespace OctoAwesome.Client.Screens
                 HorizontalAlignment = HorizontalAlignment.Left,
                 HorizontalTextAlignment = HorizontalAlignment.Left,
                 VerticalTextAlignment = VerticalAlignment.Top,
-
             };
-            Description.InvalidateDimensions();
-            DescriptionPanel.Controls.Add(Description);
+            description.InvalidateDimensions();
+            descriptionPanel.Controls.Add(description);
 
             panel.Width = 700;
+        }
 
+        private bool CheckHttpUrl(string url)
+        {
+            Uri tmp;            
+            return Uri.TryCreate(url, UriKind.Absolute, out tmp) && (tmp.Scheme == Uri.UriSchemeHttp || tmp.Scheme == Uri.UriSchemeHttps);
         }
     }
 }


### PR DESCRIPTION
* CrewMember um Links erweitert
* Crew mit Wiki abgeglichen
* Crew-Seite im Wiki wird per JS aus der XML-Datei generiert: https://github.com/ManuelHu/octocrew-js
* EDIT: Jetzt werden auch die Links im CrewMemeberScreen angezeigt - nach einer Sicherheitsüberprüfung, damit uns keiner auf ein Programm verlinkt und das dann gestartet wird.