### PR TITLE
DocFX log.txt im Ausgabeverzeichnis generieren

### DIFF
--- a/OctoAwesome/OctoAwesome.Docs/OctoAwesome.Docs.csproj
+++ b/OctoAwesome/OctoAwesome.Docs/OctoAwesome.Docs.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<LogFile>../bin/Doc/log.txt</LogFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Beim nächsten Merge mit dem master erhält dieser auch den Fix.