### PR TITLE
Settings erweitert

### DIFF
--- a/OctoAwesome/OctoAwesome.Client/Controls/OptionsOptionControl.cs
+++ b/OctoAwesome/OctoAwesome.Client/Controls/OptionsOptionControl.cs
@@ -64,7 +64,7 @@ namespace OctoAwesome.Client.Controls
 
             Checkbox disablePersistence = new Checkbox(manager)
             {
-                Checked = bool.Parse(settings.Get<string>("DisablePersistence")),
+                Checked = settings.Get("DisablePersistence", false),
                 HookBrush = new TextureBrush(manager.Game.Assets.LoadTexture(typeof(ScreenComponent), "iconCheck_brown"), TextureBrushMode.Stretch),
             };
             disablePersistence.CheckedChanged += (state) => SetPersistence(state);
@@ -110,7 +110,7 @@ namespace OctoAwesome.Client.Controls
 
             Checkbox enableFullscreen = new Checkbox(manager)
             {
-                Checked = bool.Parse(settings.Get<string>("EnableFullscreen")),
+                Checked = settings.Get<bool>("EnableFullscreen"),
                 HookBrush = new TextureBrush(manager.Game.Assets.LoadTexture(typeof(ScreenComponent), "iconCheck_brown"), TextureBrushMode.Stretch),
             };
             enableFullscreen.CheckedChanged += (state) => SetFullscreen(state);

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -53,15 +53,11 @@ namespace OctoAwesome.Client
 
             //TargetElapsedTime = new TimeSpan(0, 0, 0, 0, 15);
 
-            int width = 1080, height = 720;
-            if (Settings.KeyExists("Width"))
-                width = Settings.Get<int>("Width");
-            if (Settings.KeyExists("Height"))
-               height = Settings.Get<int>("Height");            
+            int width = Settings.Get("Width", 1080);
+            int height = Settings.Get("Height", 720);
             Window.ClientSize = new Size(width, height);
 
-            if (Settings.KeyExists("EnableFullscreen") && Settings.Get<bool>("EnableFullscreen"))
-                Window.Fullscreen = true;
+            Window.Fullscreen = Settings.Get("EnableFullscreen", false);
 
             if (Settings.KeyExists("Viewrange"))
             {

--- a/OctoAwesome/OctoAwesome.Client/Screens/LoadScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/LoadScreen.cs
@@ -135,8 +135,7 @@ namespace OctoAwesome.Client.Screens
             if (levelList.Items.Count >= 1)
                 levelList.SelectedItem = levelList.Items[0];
 
-            if (settings.KeyExists("LastUniverse") && settings.Get<string>("LastUniverse") != null
-                && settings.Get<string>("LastUniverse") != "")
+            if (settings.Get<string>("LastUniverse") != null)
             {
                 var lastlevel =  levelList.Items.FirstOrDefault(u => u.Id == Guid.Parse(settings.Get<string>("LastUniverse")));
                 if (lastlevel != null)

--- a/OctoAwesome/OctoAwesome.Runtime/ResourceManager.cs
+++ b/OctoAwesome/OctoAwesome.Runtime/ResourceManager.cs
@@ -59,7 +59,7 @@ namespace OctoAwesome.Runtime
 
             planets = new Dictionary<int, IPlanet>();
 
-            bool.TryParse(Settings.Get<string>("DisablePersistence"), out disablePersistence);
+            disablePersistence = Settings.Get("DisablePersistence", false);
         }
 
         /// <summary>

--- a/OctoAwesome/OctoAwesome.Tests/OctoAwesome.Tests.csproj
+++ b/OctoAwesome/OctoAwesome.Tests/OctoAwesome.Tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7E2C82CC-CCC7-4837-9662-9850092BDC3B}</ProjectGuid>
+    <ProjectGuid>{0468B67C-E076-4B19-833C-382513606A5A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OctoAwesome.Tests</RootNamespace>

--- a/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
+++ b/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace OctoAwesome.Tests
 {
-    
     public class SettingsManagerTests
     {
         [Fact]
@@ -13,15 +12,15 @@ namespace OctoAwesome.Tests
         {
             Settings settings = new Settings(true);
 
-            string[] testArray = new string[] {"foo", "bar"};
+            string[] testArray = new string[] { "foo", "bar" };
             settings.Set("foo", testArray);
-            
+
             string[] newArray = settings.GetArray<string>("foo");
 
             Assert.True(testArray.SequenceEqual(newArray));
 
 
-            int[] testArrayInt = new int[] { 3,5,333,456,3457};
+            int[] testArrayInt = new int[] { 3, 5, 333, 456, 3457 };
             settings.Set("fooInt", testArrayInt);
 
             int[] newArrayInt = settings.GetArray<int>("fooInt");
@@ -29,7 +28,7 @@ namespace OctoAwesome.Tests
             Assert.True(testArray.SequenceEqual(newArray));
 
 
-            bool[] testArrayBool = new bool[] { true, false};
+            bool[] testArrayBool = new bool[] { true, false };
             settings.Set("fooBool", testArrayBool);
 
             bool[] newArrayBool = settings.GetArray<bool>("fooBool");
@@ -54,21 +53,32 @@ namespace OctoAwesome.Tests
             settings.Set("inputBool", inputBool);
 
             Assert.Equal(inputBool, settings.Get<bool>("inputBool"));
-
-            
-
-
-
         }
 
         [Fact]
         public void NullTest()
         {
-
             Settings settings = new Settings(true);
 
-            int test = settings.Get<int>("foobarnotset");
-            Assert.Equal(0,test);
+            int testInt = settings.Get<int>("foobarnotset");
+            Assert.Equal(0, testInt);
+
+            string testString = settings.Get<string>("foobarnotset");
+            Assert.Equal(null, testString);
+        }
+
+        [Fact]
+        public void DeleteTest()
+        {
+            Settings settings = new Settings(true);
+
+            settings.Set("test", 1);
+            int test1 = settings.Get<int>("test");
+            Assert.Equal(1, test1);
+
+            settings.Delete("test");
+            int test2 = settings.Get<int>("test");
+            Assert.Equal(0, test2);
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
+++ b/OctoAwesome/OctoAwesome.Tests/SettingsManagerTests.cs
@@ -56,7 +56,7 @@ namespace OctoAwesome.Tests
         }
 
         [Fact]
-        public void NullTest()
+        public void UnsetTest()
         {
             Settings settings = new Settings(true);
 
@@ -65,6 +65,12 @@ namespace OctoAwesome.Tests
 
             string testString = settings.Get<string>("foobarnotset");
             Assert.Equal(null, testString);
+
+            int testIntDefault = settings.Get("foobarnotset", 42);
+            Assert.Equal(42, testIntDefault);
+
+            string testStringDefault = settings.Get("foobarnotset", "ABC");
+            Assert.Equal("ABC", testStringDefault);
         }
 
         [Fact]

--- a/OctoAwesome/OctoAwesome/ISettings.cs
+++ b/OctoAwesome/OctoAwesome/ISettings.cs
@@ -1,5 +1,8 @@
 ﻿namespace OctoAwesome
 {
+    /// <summary>
+    /// Interface zur Verwaltung der Anwendungseinstellungen
+    /// </summary>
     public interface ISettings
     {
         /// <summary>
@@ -8,6 +11,14 @@
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <returns>Der Wert der Einstellung.</returns>
         T Get<T>(string key);
+
+        /// <summary>
+        /// Gibt den Wert einer Einstellung zurück.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="defaultValue">Default-Wert, der zurückgegeben wird, wenn der key nicht vorhanden ist.</param>
+        /// <returns>Der Wert der Einstellung oder der Default-Wert.</returns>
+        T Get<T>(string key, T defaultValue);
 
         /// <summary>
         /// Gibt das Array einer Einstellung zurück

--- a/OctoAwesome/OctoAwesome/ISettings.cs
+++ b/OctoAwesome/OctoAwesome/ISettings.cs
@@ -65,5 +65,11 @@
         /// <param name="key">Der Schlüssel der Einstellung.</param>
         /// <param name="values">Der Wert der Einstellung.</param>
         void Set(string key, bool[] values);
+
+        /// <summary>
+        /// Löscht eine Eigenschaft aus den Einstellungen
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung</param>
+        void Delete(string key);
     }
 }

--- a/OctoAwesome/OctoAwesome/Settings.cs
+++ b/OctoAwesome/OctoAwesome/Settings.cs
@@ -23,7 +23,7 @@ namespace OctoAwesome
         {
             if (debug)
             {
-                ExeConfigurationFileMap map = new ExeConfigurationFileMap {ExeConfigFilename = "EXECONFIG_PATH"};
+                ExeConfigurationFileMap map = new ExeConfigurationFileMap { ExeConfigFilename = "EXECONFIG_PATH" };
                 _config = ConfigurationManager.OpenMappedExeConfiguration(map,
                     ConfigurationUserLevel.None);
             }
@@ -51,7 +51,7 @@ namespace OctoAwesome
                 return default(T);
             var valueConfig = settingElement.Value;
 
-            return (T) Convert.ChangeType(valueConfig, typeof(T));
+            return (T)Convert.ChangeType(valueConfig, typeof(T));
         }
 
         /// <summary>
@@ -74,8 +74,6 @@ namespace OctoAwesome
         /// <returns></returns>
         public bool KeyExists(string key)
         {
-          
-
             return _config.AppSettings.Settings.AllKeys.Contains(key);
         }
 
@@ -86,7 +84,7 @@ namespace OctoAwesome
         /// <param name="value">Der Wert der Einstellung.</param>
         public void Set(string key, string value)
         {
-        
+
 
             if (_config.AppSettings.Settings.AllKeys.Contains(key))
                 _config.AppSettings.Settings[key].Value = value;
@@ -169,18 +167,26 @@ namespace OctoAwesome
             // Wir müssten, um beide Klammern zu entfernen, - 3 rechnen. Ich lasse die letzte Klammer stellvertretend für das Komma, was folgen würde, stehen.
             // Das wird in der for-Schleife auseinander gepflückt.
 
-
             arrayString = arrayString.Substring(1, arrayString.Length - 2 /*- 1*/);
 
             string[] partsString = arrayString.Split(',');
             T[] tArray = new T[partsString.Length];
             for (int i = 0; i < partsString.Length; i++)
             {
-                tArray[i] = (T) Convert.ChangeType(partsString[i], typeof(T));
+                tArray[i] = (T)Convert.ChangeType(partsString[i], typeof(T));
             }
 
-
             return tArray;
+        }
+
+        /// <summary>
+        /// Löscht eine Eigenschaft aus den Einstellungen
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung</param>
+        public void Delete(string key)
+        {
+            _config.AppSettings.Settings.Remove(key);
+            _config.Save(ConfigurationSaveMode.Modified, false);
         }
     }
 }

--- a/OctoAwesome/OctoAwesome/Settings.cs
+++ b/OctoAwesome/OctoAwesome/Settings.cs
@@ -13,12 +13,13 @@ namespace OctoAwesome
     /// </summary>
     public class Settings : ISettings
     {
-        /// <summary>
-        /// Bei UnitTests ist Assembly.GetEntryAssembly null, Gründe dazu gibts auf StackOverflow.
-        /// Um Schmerzen zu vermeiden wurde eine Variable eingeführt, die unabhängig testet.
-        /// </summary>
-
         private Configuration _config;
+
+        /// <summary>
+        /// Erzeugt eine neue Instanz der Klasse Settings, die auf die Konfigurationsdatei der aktuell laufenden Anwendung zugreift.
+        /// </summary>
+        /// <param name="debug">Bei UnitTests ist Assembly.GetEntryAssembly null, Gründe dazu gibts auf StackOverflow.
+        /// Um Schmerzen zu vermeiden wurde eine Variable eingeführt, die unabhängig testet.</param>
         internal Settings(bool debug)
         {
             if (debug)
@@ -32,6 +33,10 @@ namespace OctoAwesome
                 _config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
             }
         }
+
+        /// <summary>
+        /// Erzeugt eine neue Instanz der Klasse Settings, die auf die Konfigurationsdatei der aktuell laufenden Anwendung zugreift.
+        /// </summary>
         public Settings()
         {
             _config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
@@ -44,11 +49,20 @@ namespace OctoAwesome
         /// <returns>Der Wert der Einstellung.</returns>
         public T Get<T>(string key)
         {
-            // var config = ConfigurationManager.OpenExeConfiguration(Assembly.GetEntryAssembly().Location);
+            return Get<T>(key, default(T));
+        }
 
+        /// <summary>
+        /// Gibt den Wert einer Einstellung zurück.
+        /// </summary>
+        /// <param name="key">Der Schlüssel der Einstellung.</param>
+        /// <param name="defaultValue">Default-Wert, der zurückgegeben wird, wenn der key nicht vorhanden ist.</param>
+        /// <returns>Der Wert der Einstellung oder der Default-Wert.</returns>
+        public T Get<T>(string key, T defaultValue)
+        {
             var settingElement = _config.AppSettings.Settings[key];
             if (settingElement == null)
-                return default(T);
+                return defaultValue;
             var valueConfig = settingElement.Value;
 
             return (T)Convert.ChangeType(valueConfig, typeof(T));
@@ -84,8 +98,6 @@ namespace OctoAwesome
         /// <param name="value">Der Wert der Einstellung.</param>
         public void Set(string key, string value)
         {
-
-
             if (_config.AppSettings.Settings.AllKeys.Contains(key))
                 _config.AppSettings.Settings[key].Value = value;
             else
@@ -120,12 +132,10 @@ namespace OctoAwesome
         /// <param name="values">Der Wert der Einstellung.</param>
         public void Set(string key, string[] values)
         {
-            /* Wir bauen das Array in eine Art serialisierten String um.
-             * Wenn eine Zeichenkette, die wir aus den Einstellugen lesen mit einer
-             * eckigen Klammer anfängt, ist es ein Array.
-             * [value1, value2, value3]
-             * 
-             */
+            // Wir bauen das Array in eine Art serialisierten String um.
+            // Wenn eine Zeichenkette, die wir aus den Einstellugen lesen mit einer
+            // eckigen Klammer anfängt, ist es ein Array.
+            // [value1, value2, value3]
 
             string writeString = "[" + String.Join(",", values) + "]";
             Set(key, writeString);
@@ -140,9 +150,7 @@ namespace OctoAwesome
         {
             string[] strValues = new string[values.Length];
             for (int i = 0; i < values.Length; i++)
-            {
                 strValues[i] = Convert.ToString(values[i]);
-            }
             Set(key, strValues);
         }
 
@@ -155,9 +163,7 @@ namespace OctoAwesome
         {
             string[] stringValues = new string[values.Length];
             for (int i = 0; i < values.Length; i++)
-            {
                 stringValues[i] = Convert.ToString(values[i]);
-            }
             Set(key, stringValues);
         }
 
@@ -172,9 +178,7 @@ namespace OctoAwesome
             string[] partsString = arrayString.Split(',');
             T[] tArray = new T[partsString.Length];
             for (int i = 0; i < partsString.Length; i++)
-            {
                 tArray[i] = (T)Convert.ChangeType(partsString[i], typeof(T));
-            }
 
             return tArray;
         }


### PR DESCRIPTION
- Neben `default(T)` können eigenen Default-Werte angegeben werden - das spart uns einige `KeyExists`-Aufrufe.
- Löschen von Keys ist jetzt möglich (aber noch kein Einsatzgebiet)
- Tests erweitert (`Nulltest` => `UnsetTest`, neuer `DeleteTest`)
- Die neuen Funktionen werden auch schon im `OctoGame`, dem `ResourceManager` und den Screens eingesetzt.

Siehe auch #166 