### PR TITLE
Inventar: Zentrale Verwaltungsmethoden

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Items/PickAxeDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Items/PickAxeDefinition.cs
@@ -41,6 +41,8 @@ namespace OctoAwesome.Basics.Definitions.Items
             }
         }
 
+        decimal IInventoryableDefinition.VolumePerUnit => 1;
+
         public PhysicalProperties GetProperties(IItem item)
         {
             return new PhysicalProperties()

--- a/OctoAwesome/OctoAwesome.Basics/Definitions/Items/WauziEggDefinition.cs
+++ b/OctoAwesome/OctoAwesome.Basics/Definitions/Items/WauziEggDefinition.cs
@@ -33,5 +33,7 @@
                 return 1;
             }
         }
+
+        decimal IInventoryableDefinition.VolumePerUnit => 1;
     }
 }

--- a/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
+++ b/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using engenious;
-using OctoAwesome.Basics.EntityComponents;
 
 namespace OctoAwesome.Basics.SimulationComponents
 {
@@ -41,7 +40,8 @@ namespace OctoAwesome.Basics.SimulationComponents
                 if (lastBlock != 0)
                 {
                     var blockDefinition = simulation.ResourceManager.DefinitionManager.GetDefinitionByIndex(lastBlock);
-                    inventory.AddOfType(blockDefinition);
+                    if (blockDefinition is IInventoryableDefinition invDef)
+                        inventory.AddUnit(invDef);
                 }
                 controller.InteractBlock = null;
             }
@@ -99,8 +99,7 @@ namespace OctoAwesome.Basics.SimulationComponents
 
                         if (!intersects)
                         {
-                            var succeeded = inventory.RemoveUnit(toolbar.ActiveTool);
-                            if (succeeded)
+                            if (inventory.RemoveUnit(toolbar.ActiveTool))
                             {
                                 entity.Cache.SetBlock(idx, simulation.ResourceManager.DefinitionManager.GetDefinitionIndex(definition));
                                 if (toolbar.ActiveTool.Amount <= 0)

--- a/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
+++ b/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
@@ -54,20 +54,11 @@ namespace OctoAwesome.Basics.SimulationComponents
                         };
                         inventory.Inventory.Add(slot);
 
-                        
+
                         if (toolbar != null)
-                        {
-                            for (int i = 0; i < toolbar.Tools.Length; i++)
-                            {
-                                if (toolbar.Tools[i] == null)
-                                {
-                                    toolbar.Tools[i] = slot;
-                                    break;
-                                }
-                            }
-                        }
+                            toolbar.AddNewSlot(slot);
                     }
-                    slot.Amount += 125;
+                    slot.Amount += 125; //TODO: Hardcoded?
                 }
                 controller.InteractBlock = null;
             }
@@ -113,7 +104,7 @@ namespace OctoAwesome.Basics.SimulationComponents
                                 );
 
                             // Nicht in sich selbst reinbauen
-                            
+
                             foreach (var box in boxes)
                             {
                                 var newBox = new BoundingBox(idx + box.Min, idx + box.Max);
@@ -123,22 +114,17 @@ namespace OctoAwesome.Basics.SimulationComponents
                                     intersects = true;
                             }
                         }
-                       
+
 
                         if (!intersects)
                         {
                             entity.Cache.SetBlock(idx, simulation.ResourceManager.DefinitionManager.GetDefinitionIndex(definition));
 
-                            toolbar.ActiveTool.Amount -= 125;
+                            toolbar.ActiveTool.Amount -= 125; //TODO: Hardcoded?
                             if (toolbar.ActiveTool.Amount <= 0)
                             {
                                 inventory.Inventory.Remove(toolbar.ActiveTool);
-                                for (int i = 0; i < toolbar.Tools.Length; i++)
-                                {
-                                    if (toolbar.Tools[i] == toolbar.ActiveTool)
-                                        toolbar.Tools[i] = null;
-                                }
-                                toolbar.ActiveTool = null;
+                                toolbar.RemoveSlot(toolbar.ActiveTool);
                             }
                         }
                     }

--- a/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
@@ -194,42 +194,11 @@ namespace OctoAwesome.Client.Components
 
             var blockDefinitions = resourceManager.DefinitionManager.GetBlockDefinitions();
             foreach (var blockDefinition in blockDefinitions)
-            {
-                decimal limit = blockDefinition.VolumePerUnit * blockDefinition.StackLimit;
-                var slot = inventory.Inventory.FirstOrDefault(s => s.Definition == blockDefinition && s.Amount < limit);
-
-                // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
-                if (slot == null)
-                {
-                    slot = new InventorySlot()
-                    {
-                        Definition = blockDefinition,
-                        Amount = 0
-                    };
-                    inventory.Inventory.Add(slot);
-                }
-                slot.Amount += blockDefinition.VolumePerUnit;
-            }
+                inventory.AddOfType(blockDefinition);
 
             var itemDefinitions = resourceManager.DefinitionManager.GetItemDefinitions();
             foreach (var itemDefinition in itemDefinitions)
-            {
-                decimal limit = itemDefinition.StackLimit;
-                var slot = inventory.Inventory.Where(s => s.Definition == itemDefinition && s.Amount < limit).FirstOrDefault();
-
-                // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
-                if (slot == null)
-                {
-                    slot = new InventorySlot()
-                    {
-                        Definition = itemDefinition,
-                        Amount = 0
-                    };
-                    inventory.Inventory.Add(slot);
-                }
-                slot.Amount++; //TODO: Hardcoded
-            }
-
+                inventory.AddOfType(itemDefinition);
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
@@ -196,10 +196,10 @@ namespace OctoAwesome.Client.Components
             foreach (var blockDefinition in blockDefinitions)
             {
 
-                var slot = inventory.Inventory.Where(s => s.Definition == blockDefinition && s.Amount < blockDefinition.StackLimit).FirstOrDefault();
+                var slot = inventory.Inventory.Where(s => s.Definition == blockDefinition /*&& s.Amount < blockDefinition.StackLimit*/).FirstOrDefault();
 
                 // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
-                if (slot == null || slot.Amount >= blockDefinition.StackLimit)
+                if (slot == null /*|| slot.Amount >= blockDefinition.StackLimit*/)
                 {
                     slot = new InventorySlot()
                     {
@@ -208,7 +208,7 @@ namespace OctoAwesome.Client.Components
                     };
                     inventory.Inventory.Add(slot);
                 }
-                slot.Amount++;
+                slot.Amount+=125; //TODO: Hardcoded?
             }
 
             var itemDefinitions = resourceManager.DefinitionManager.GetItemDefinitions();

--- a/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
@@ -195,11 +195,11 @@ namespace OctoAwesome.Client.Components
             var blockDefinitions = resourceManager.DefinitionManager.GetBlockDefinitions();
             foreach (var blockDefinition in blockDefinitions)
             {
-
-                var slot = inventory.Inventory.Where(s => s.Definition == blockDefinition /*&& s.Amount < blockDefinition.StackLimit*/).FirstOrDefault();
+                decimal limit = blockDefinition.VolumePerUnit * blockDefinition.StackLimit;
+                var slot = inventory.Inventory.FirstOrDefault(s => s.Definition == blockDefinition && s.Amount < limit);
 
                 // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
-                if (slot == null /*|| slot.Amount >= blockDefinition.StackLimit*/)
+                if (slot == null)
                 {
                     slot = new InventorySlot()
                     {
@@ -208,26 +208,26 @@ namespace OctoAwesome.Client.Components
                     };
                     inventory.Inventory.Add(slot);
                 }
-                slot.Amount+=125; //TODO: Hardcoded?
+                slot.Amount += blockDefinition.VolumePerUnit;
             }
 
             var itemDefinitions = resourceManager.DefinitionManager.GetItemDefinitions();
-            foreach (var blockDefinition in itemDefinitions)
+            foreach (var itemDefinition in itemDefinitions)
             {
-
-                var slot = inventory.Inventory.Where(s => s.Definition == blockDefinition && s.Amount < blockDefinition.StackLimit).FirstOrDefault();
+                decimal limit = itemDefinition.StackLimit;
+                var slot = inventory.Inventory.Where(s => s.Definition == itemDefinition && s.Amount < limit).FirstOrDefault();
 
                 // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
-                if (slot == null || slot.Amount >= blockDefinition.StackLimit)
+                if (slot == null)
                 {
                     slot = new InventorySlot()
                     {
-                        Definition = blockDefinition,
+                        Definition = itemDefinition,
                         Amount = 0
                     };
                     inventory.Inventory.Add(slot);
                 }
-                slot.Amount++;
+                slot.Amount++; //TODO: Hardcoded
             }
 
         }

--- a/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/PlayerComponent.cs
@@ -194,11 +194,11 @@ namespace OctoAwesome.Client.Components
 
             var blockDefinitions = resourceManager.DefinitionManager.GetBlockDefinitions();
             foreach (var blockDefinition in blockDefinitions)
-                inventory.AddOfType(blockDefinition);
+                inventory.AddUnit(blockDefinition);
 
             var itemDefinitions = resourceManager.DefinitionManager.GetItemDefinitions();
             foreach (var itemDefinition in itemDefinitions)
-                inventory.AddOfType(itemDefinition);
+                inventory.AddUnit(itemDefinition);
         }
     }
 }

--- a/OctoAwesome/OctoAwesome.Client/OctoGame.cs
+++ b/OctoAwesome/OctoAwesome.Client/OctoGame.cs
@@ -84,7 +84,7 @@ namespace OctoAwesome.Client
             Assets = new AssetComponent(this);
             Components.Add(Assets);
 
-            Simulation = new Components.SimulationComponent(this, 
+            Simulation = new Components.SimulationComponent(this,
                 extensionLoader, ResourceManager);
             Simulation.UpdateOrder = 4;
             Components.Add(Simulation);
@@ -135,16 +135,8 @@ namespace OctoAwesome.Client
             KeyMapper.RegisterBinding("octoawesome:apply", Languages.OctoKeys.apply);
             KeyMapper.RegisterBinding("octoawesome:flymode", Languages.OctoKeys.flymode);
             KeyMapper.RegisterBinding("octoawesome:jump", Languages.OctoKeys.jump);
-            KeyMapper.RegisterBinding("octoawesome:slot0", Languages.OctoKeys.slot0);
-            KeyMapper.RegisterBinding("octoawesome:slot1", Languages.OctoKeys.slot1);
-            KeyMapper.RegisterBinding("octoawesome:slot2", Languages.OctoKeys.slot2);
-            KeyMapper.RegisterBinding("octoawesome:slot3", Languages.OctoKeys.slot3);
-            KeyMapper.RegisterBinding("octoawesome:slot4", Languages.OctoKeys.slot4);
-            KeyMapper.RegisterBinding("octoawesome:slot5", Languages.OctoKeys.slot5);
-            KeyMapper.RegisterBinding("octoawesome:slot6", Languages.OctoKeys.slot6);
-            KeyMapper.RegisterBinding("octoawesome:slot7", Languages.OctoKeys.slot7);
-            KeyMapper.RegisterBinding("octoawesome:slot8", Languages.OctoKeys.slot8);
-            KeyMapper.RegisterBinding("octoawesome:slot9", Languages.OctoKeys.slot9);
+            for (int i = 0; i < 10; i++)
+                KeyMapper.RegisterBinding("octoawesome:slot" + i, Languages.OctoKeys.ResourceManager.GetString("slot" + i));
             KeyMapper.RegisterBinding("octoawesome:debug.allblocks", Languages.OctoKeys.debug_allblocks);
             KeyMapper.RegisterBinding("octoawesome:debug.control", Languages.OctoKeys.debug_control);
             KeyMapper.RegisterBinding("octoawesome:inventory", Languages.OctoKeys.inventory);

--- a/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
@@ -220,56 +220,15 @@ namespace OctoAwesome.Client.Screens
                 if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
                 Manager.Player.JumpInput = true;
             });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot0", type =>
+            for (int i = 0; i < 10; i++)
             {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[0] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot1", type =>
-            {
-                if (!IsActiveScreen) return;
-                Manager.Player.SlotInput[1] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot2", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[2] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot3", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[3] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot4", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[4] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot5", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[5] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot6", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[6] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot7", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[7] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot8", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[8] = true;
-            });
-            Manager.Game.KeyMapper.AddAction("octoawesome:slot9", type =>
-            {
-                if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
-                Manager.Player.SlotInput[9] = true;
-            });
+                int tmp = i; // Nicht löschen. Benötigt, um aktuellen Wert zu fangen.
+                Manager.Game.KeyMapper.AddAction("octoawesome:slot" + tmp, type =>
+                {
+                    if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
+                    Manager.Player.SlotInput[tmp] = true;
+                });
+            }
             Manager.Game.KeyMapper.AddAction("octoawesome:debug.allblocks", type =>
             {
                 if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
@@ -311,10 +270,9 @@ namespace OctoAwesome.Client.Screens
             {
                 if (!IsActiveScreen || type != KeyMapper.KeyType.Down) return;
                 Manager.NavigateToScreen(new TargetScreen(Manager, (x, y) => {
-                    Manager.Game.Player.Position.Position = new Coordinate(0, new Index3(x, y, 300), new Vector3());
-                    Manager.NavigateBack();
+                        Manager.Game.Player.Position.Position = new Coordinate(0, new Index3(x, y, 300), new Vector3());
+                        Manager.NavigateBack();
                     }, Manager.Game.Player.Position.Position.GlobalBlockIndex.X, Manager.Game.Player.Position.Position.GlobalBlockIndex.Y));
-                
             });
         }
 

--- a/OctoAwesome/OctoAwesome.Client/Screens/InventoryScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/InventoryScreen.cs
@@ -147,26 +147,18 @@ namespace OctoAwesome.Client.Screens
                         // Swap
                         int targetIndex = (int)image.Tag;
                         InventorySlot targetSlot = player.Toolbar.Tools[targetIndex];
-                        int sourceIndex = -1;
+
                         InventorySlot sourceSlot = e.Content as InventorySlot;
+                        int sourceIndex = player.Toolbar.GetSlotIndex(sourceSlot);
 
-                        for (int j = 0; j < player.Toolbar.Tools.Length; j++)
-                        {
-                            if (player.Toolbar.Tools[j] == sourceSlot)
-                            {
-                                sourceIndex = j;
-                                break;
-                            }
-                        }
-
-                        SetTool(sourceSlot, targetIndex);
-                        SetTool(targetSlot, sourceIndex);
+                        player.Toolbar.SetTool(sourceSlot, targetIndex);
+                        player.Toolbar.SetTool(targetSlot, sourceIndex);
                     }
                     else
                     {
                         // Inventory Drop
                         InventorySlot slot = e.Content as InventorySlot;
-                        SetTool(slot, (int)image.Tag);
+                        player.Toolbar.SetTool(slot, (int)image.Tag);
                     }
                 };
 
@@ -184,11 +176,7 @@ namespace OctoAwesome.Client.Screens
             if (args.Sender is Grid)
             {
                 InventorySlot slot = args.Content as InventorySlot;
-                for (int i = 0; i < player.Toolbar.Tools.Length; i++)
-                {
-                    if (player.Toolbar.Tools[i] == slot)
-                        player.Toolbar.Tools[i] = null;
-                }
+                player.Toolbar.RemoveSlot(slot);
             }
         }
 
@@ -197,16 +185,16 @@ namespace OctoAwesome.Client.Screens
             // Tool neu zuweisen
             switch (args.Key)
             {
-                case Keys.D1: SetTool(inventory.HoveredSlot, 0); args.Handled = true; break;
-                case Keys.D2: SetTool(inventory.HoveredSlot, 1); args.Handled = true; break;
-                case Keys.D3: SetTool(inventory.HoveredSlot, 2); args.Handled = true; break;
-                case Keys.D4: SetTool(inventory.HoveredSlot, 3); args.Handled = true; break;
-                case Keys.D5: SetTool(inventory.HoveredSlot, 4); args.Handled = true; break;
-                case Keys.D6: SetTool(inventory.HoveredSlot, 5); args.Handled = true; break;
-                case Keys.D7: SetTool(inventory.HoveredSlot, 6); args.Handled = true; break;
-                case Keys.D8: SetTool(inventory.HoveredSlot, 7); args.Handled = true; break;
-                case Keys.D9: SetTool(inventory.HoveredSlot, 8); args.Handled = true; break;
-                case Keys.D0: SetTool(inventory.HoveredSlot, 9); args.Handled = true; break;
+                case Keys.D1: player.Toolbar.SetTool(inventory.HoveredSlot, 0); args.Handled = true; break;
+                case Keys.D2: player.Toolbar.SetTool(inventory.HoveredSlot, 1); args.Handled = true; break;
+                case Keys.D3: player.Toolbar.SetTool(inventory.HoveredSlot, 2); args.Handled = true; break;
+                case Keys.D4: player.Toolbar.SetTool(inventory.HoveredSlot, 3); args.Handled = true; break;
+                case Keys.D5: player.Toolbar.SetTool(inventory.HoveredSlot, 4); args.Handled = true; break;
+                case Keys.D6: player.Toolbar.SetTool(inventory.HoveredSlot, 5); args.Handled = true; break;
+                case Keys.D7: player.Toolbar.SetTool(inventory.HoveredSlot, 6); args.Handled = true; break;
+                case Keys.D8: player.Toolbar.SetTool(inventory.HoveredSlot, 7); args.Handled = true; break;
+                case Keys.D9: player.Toolbar.SetTool(inventory.HoveredSlot, 8); args.Handled = true; break;
+                case Keys.D0: player.Toolbar.SetTool(inventory.HoveredSlot, 9); args.Handled = true; break;
             }
 
             if (Manager.CanGoBack && (args.Key == Keys.Escape || args.Key == Keys.I))
@@ -216,18 +204,6 @@ namespace OctoAwesome.Client.Screens
             }
 
             base.OnKeyDown(args);
-        }
-
-        private void SetTool(InventorySlot slot, int index)
-        {
-            // Alle Slots entfernen die das selbe Tool enthalten
-            for (int i = 0; i < player.Toolbar.Tools.Length; i++)
-            {
-                if (player.Toolbar.Tools[i] == slot)
-                    player.Toolbar.Tools[i] = null;
-            }
-
-            player.Toolbar.Tools[index] = slot;
         }
 
         protected override void OnUpdate(GameTime gameTime)

--- a/OctoAwesome/OctoAwesome.Client/Screens/InventoryScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/InventoryScreen.cs
@@ -5,7 +5,6 @@ using engenious.Input;
 using System.Collections.Generic;
 using OctoAwesome.Client.Controls;
 using engenious;
-using OctoAwesome.Runtime;
 using OctoAwesome.EntityComponents;
 
 namespace OctoAwesome.Client.Screens
@@ -13,7 +12,6 @@ namespace OctoAwesome.Client.Screens
     internal sealed class InventoryScreen : Screen
     {
         private Dictionary<string, Texture2D> toolTextures = new Dictionary<string, Texture2D>();
-
 
         private PlayerComponent player;
 
@@ -43,12 +41,9 @@ namespace OctoAwesome.Client.Screens
                 toolTextures.Add(item.GetType().FullName, texture);
             }
 
-
-
             player = manager.Player;
 
             IsOverlay = true;
-
             Background = new BorderBrush(Color.Black * 0.3f);
 
             backgroundBrush = new BorderBrush(Color.Black);
@@ -183,18 +178,11 @@ namespace OctoAwesome.Client.Screens
         protected override void OnKeyDown(KeyEventArgs args)
         {
             // Tool neu zuweisen
-            switch (args.Key)
+            if ((int)args.Key >= (int)Keys.D0 && (int)args.Key <= (int)Keys.D9)
             {
-                case Keys.D1: player.Toolbar.SetTool(inventory.HoveredSlot, 0); args.Handled = true; break;
-                case Keys.D2: player.Toolbar.SetTool(inventory.HoveredSlot, 1); args.Handled = true; break;
-                case Keys.D3: player.Toolbar.SetTool(inventory.HoveredSlot, 2); args.Handled = true; break;
-                case Keys.D4: player.Toolbar.SetTool(inventory.HoveredSlot, 3); args.Handled = true; break;
-                case Keys.D5: player.Toolbar.SetTool(inventory.HoveredSlot, 4); args.Handled = true; break;
-                case Keys.D6: player.Toolbar.SetTool(inventory.HoveredSlot, 5); args.Handled = true; break;
-                case Keys.D7: player.Toolbar.SetTool(inventory.HoveredSlot, 6); args.Handled = true; break;
-                case Keys.D8: player.Toolbar.SetTool(inventory.HoveredSlot, 7); args.Handled = true; break;
-                case Keys.D9: player.Toolbar.SetTool(inventory.HoveredSlot, 8); args.Handled = true; break;
-                case Keys.D0: player.Toolbar.SetTool(inventory.HoveredSlot, 9); args.Handled = true; break;
+                int offset = (int)args.Key - (int)Keys.D0;
+                player.Toolbar.SetTool(inventory.HoveredSlot, offset);
+                args.Handled = true;
             }
 
             if (Manager.CanGoBack && (args.Key == Keys.Escape || args.Key == Keys.I))
@@ -210,10 +198,8 @@ namespace OctoAwesome.Client.Screens
         {
             base.OnUpdate(gameTime);
 
-            nameLabel.Text = inventory.HoveredSlot != null ? inventory.HoveredSlot.Definition.Name : string.Empty;
-            massLabel.Text = inventory.HoveredSlot != null ? inventory.HoveredSlot.Amount.ToString() : string.Empty;
-            volumeLabel.Text = inventory.HoveredSlot != null ? inventory.HoveredSlot.Amount.ToString() : string.Empty;
-
+            nameLabel.Text = inventory.HoveredSlot?.Definition.Name ?? "";
+            massLabel.Text = volumeLabel.Text = inventory.HoveredSlot?.Amount.ToString() ?? "";
 
             // Aktualisierung des aktiven Buttons
             for (int i = 0; i < ToolBarComponent.TOOLCOUNT; i++)

--- a/OctoAwesome/OctoAwesome/BlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome/BlockDefinition.cs
@@ -21,12 +21,12 @@ namespace OctoAwesome
         /// <summary>
         /// Die maximale Stackgrösse
         /// </summary>
-        public virtual int StackLimit { get { return 100; } }
+        public virtual int StackLimit { get { return 2; } }
 
         /// <summary>
         /// Gibt das Volumen für eine Einheit an.
         /// </summary>
-        public virtual float VolumePerUnit { get { return 125; } }
+        public virtual decimal VolumePerUnit { get { return 125; } }
 
         /// <summary>
         /// Array, das alle Texturen für alle Seiten des Blocks enthält
@@ -56,7 +56,7 @@ namespace OctoAwesome
         public abstract void Hit(IBlockDefinition block, PhysicalProperties itemProperties);
 
         /// <summary>
-        /// Liefert die Kollisionsbox für den Block. Da ein Array zurück gegeben wird, lässt sich die 
+        /// Liefert die Kollisionsbox für den Block. Da ein Array zurück gegeben wird, lässt sich die
         /// </summary>
         /// <param name="manager">[Bitte ergänzen]</param>
         /// <param name="x">X-Anteil der Koordinate des Blocks</param>

--- a/OctoAwesome/OctoAwesome/BlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome/BlockDefinition.cs
@@ -21,7 +21,7 @@ namespace OctoAwesome
         /// <summary>
         /// Die maximale Stackgrösse
         /// </summary>
-        public virtual int StackLimit { get { return 2; } }
+        public virtual int StackLimit { get { return 100; } }
 
         /// <summary>
         /// Gibt das Volumen für eine Einheit an.

--- a/OctoAwesome/OctoAwesome/EntityComponents/InventoryComponent.cs
+++ b/OctoAwesome/OctoAwesome/EntityComponents/InventoryComponent.cs
@@ -54,5 +54,62 @@ namespace OctoAwesome.EntityComponents
                 writer.Write(slot.Amount);
             }
         }
+
+        /// <summary>
+        /// Fügt ein Element des angegebenen Definitionstyps hinzu.
+        /// </summary>
+        /// <param name="definition">Die Definition.</param>
+        public void AddOfType(IDefinition definition)
+        {
+            //TODO: Unschön, StackLimit & VolumePerUnit müssen in IDefinition!
+            decimal limit = 0, volume = 0;
+            if (definition is IBlockDefinition blockDefinition)
+            {
+                limit = blockDefinition.VolumePerUnit * blockDefinition.StackLimit;
+                volume = blockDefinition.VolumePerUnit;
+            }
+            else if (definition is IItemDefinition itemDefinition)
+            {
+                limit = itemDefinition.StackLimit;
+                volume = 1; //TODO: Hardcoded
+            }
+            else
+                throw new NotImplementedException("Inventory only supports Blocks and Items.");
+
+            var slot = Inventory.FirstOrDefault(s => s.Definition == definition && s.Amount < limit);
+
+            // Wenn noch kein Slot da ist oder der vorhandene voll, dann neuen Slot
+            if (slot == null)
+            {
+                slot = new InventorySlot()
+                {
+                    Definition = definition,
+                    Amount = 0
+                };
+                Inventory.Add(slot);
+            }
+            slot.Amount += volume;
+        }
+
+        /// <summary>
+        /// Entfernt eine Einheit vom angegebenen Slot.
+        /// </summary>
+        /// <param name="slot">DEr Slot, aus dem entfernt werden soll.</param>
+        /// <returns>Gibt an, ob das entfernen der Einheit aus dem Inventar funktioniert hat. False, z.B. wenn nicht genügend Volumen (weniger als VolumePerUnit) übrig ist-</returns>
+        public bool RemoveUnit(InventorySlot slot)
+        {
+            //TODO: Das ist jetzt richtig unschön, wenn wir mal Tools einführen sollten (zum xten Mal)...
+            if (!(slot.Definition is IBlockDefinition))
+                return false;
+            var bdef = (IBlockDefinition)slot.Definition;
+            if (slot.Amount >= bdef.VolumePerUnit) // Wir können noch einen Block setzen
+            {
+                slot.Amount -= bdef.VolumePerUnit;
+                if (slot.Amount <= 0)
+                    Inventory.Remove(slot);
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/OctoAwesome/OctoAwesome/EntityComponents/ToolBarComponent.cs
+++ b/OctoAwesome/OctoAwesome/EntityComponents/ToolBarComponent.cs
@@ -75,5 +75,21 @@ namespace OctoAwesome.EntityComponents
 
             return -1;
         }
+
+        /// <summary>
+        /// Fügt einen neuen InventorySlot an der ersten freien Stelle hinzu.
+        /// </summary>
+        /// <param name="slot"></param>
+        public void AddNewSlot(InventorySlot slot)
+        {
+            for (int i = 0; i < Tools.Length; i++)
+            {
+                if (Tools[i] == null)
+                {
+                    Tools[i] = slot;
+                    break;
+                }
+            }
+        }
     }
 }

--- a/OctoAwesome/OctoAwesome/EntityComponents/ToolBarComponent.cs
+++ b/OctoAwesome/OctoAwesome/EntityComponents/ToolBarComponent.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace OctoAwesome.EntityComponents
 {
+    /// <summary>
+    /// EntityComponent, die eine Werkzeug-Toolbar für den Apieler bereitstellt.
+    /// </summary>
     public class ToolBarComponent : EntityComponent
     {
         /// <summary>
@@ -17,11 +21,59 @@ namespace OctoAwesome.EntityComponents
         /// Auflistung der Werkzeuge die der Spieler in seiner Toolbar hat.
         /// </summary>
         public InventorySlot[] Tools { get; set; }
+
+        /// <summary>
+        /// Derzeit aktives Werkzeug des Spielers
+        /// </summary>
         public InventorySlot ActiveTool { get; set; }
 
+        /// <summary>
+        /// Erzeugte eine neue ToolBarComponent
+        /// </summary>
         public ToolBarComponent()
         {
             Tools = new InventorySlot[TOOLCOUNT];
+        }
+
+        /// <summary>
+        /// Entfernt einen InventorySlot aus der Toolbar
+        /// </summary>
+        /// <param name="slot"></param>
+        public void RemoveSlot(InventorySlot slot)
+        {
+            for (int i = 0; i < Tools.Length; i++)
+            {
+                if (Tools[i] == slot)
+                    Tools[i] = null;
+            }
+            if (ActiveTool == slot)
+                ActiveTool = null;
+        }
+
+        /// <summary>
+        /// Setzt einen InventorySlot an eine Stelle in der Toolbar und löscht ggf. vorher den Slot aus alten Positionen.
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <param name="index"></param>
+        public void SetTool(InventorySlot slot, int index)
+        {
+            RemoveSlot(slot);
+
+            Tools[index] = slot;
+        }
+
+        /// <summary>
+        /// Gibt den Index eines InventorySlots in der Toolbar zurück.
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <returns>Den Index des Slots, falls nicht gefunden -1.</returns>
+        public int GetSlotIndex(InventorySlot slot)
+        {
+            for (int j = 0; j < Tools.Length; j++)
+                if (Tools[j] == slot)
+                    return j;
+
+            return -1;
         }
     }
 }

--- a/OctoAwesome/OctoAwesome/IBlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome/IBlockDefinition.cs
@@ -11,12 +11,11 @@ namespace OctoAwesome
         /// <summary>
         /// Gibt das Volumen für eine Einheit an.
         /// </summary>
-        float VolumePerUnit { get; }
+        decimal VolumePerUnit { get; }
 
         /// <summary>
-        /// Gibt an, wie viele dieses Items im Inventar in einem Slot gestapelt werden können
+        /// Gibt an, wie viele dieses Items im Inventar in einem Slot gestapelt werden können (in Anzahl der Blöcke, nicht in Vielfachen der <see cref="VolumePerUnit"/>!).
         /// </summary>
-        [Obsolete]
         int StackLimit { get; }
 
         /// <summary>
@@ -37,7 +36,7 @@ namespace OctoAwesome
         bool HasMetaData { get; }
 
         /// <summary>
-        /// Liefert die Kollisionsbox für den Block. Da ein Array zurück gegeben wird, lässt sich die 
+        /// Liefert die Kollisionsbox für den Block. Da ein Array zurück gegeben wird, lässt sich die
         /// </summary>
         /// <param name="manager">[Bitte ergänzen]</param>
         /// <param name="x">X-Anteil der Koordinate des Blocks</param>

--- a/OctoAwesome/OctoAwesome/IBlockDefinition.cs
+++ b/OctoAwesome/OctoAwesome/IBlockDefinition.cs
@@ -6,18 +6,8 @@ namespace OctoAwesome
     /// <summary>
     /// Basisinterface für eine Blockdefinition
     /// </summary>
-    public interface IBlockDefinition : IDefinition
+    public interface IBlockDefinition : IInventoryableDefinition, IDefinition
     {
-        /// <summary>
-        /// Gibt das Volumen für eine Einheit an.
-        /// </summary>
-        decimal VolumePerUnit { get; }
-
-        /// <summary>
-        /// Gibt an, wie viele dieses Items im Inventar in einem Slot gestapelt werden können (in Anzahl der Blöcke, nicht in Vielfachen der <see cref="VolumePerUnit"/>!).
-        /// </summary>
-        int StackLimit { get; }
-
         /// <summary>
         /// Geplante Methode, mit der der Block auf Interaktion von aussen reagieren kann.
         /// </summary>

--- a/OctoAwesome/OctoAwesome/IInventoryableDefinition.cs
+++ b/OctoAwesome/OctoAwesome/IInventoryableDefinition.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OctoAwesome
+{
+    /// <summary>
+    /// Basis-Interface für alle im Inventar-Verwaltbaren Definitionen.
+    /// </summary>
+    public interface IInventoryableDefinition : IDefinition
+    {
+        /// <summary>
+        /// Gibt das Volumen für eine Einheit an.
+        /// </summary>
+        decimal VolumePerUnit { get; }
+
+        /// <summary>
+        /// Gibt an, wie viele dieses Items im Inventar in einem Slot gestapelt werden können (in Anzahl der Blöcke, nicht in Vielfachen der <see cref="VolumePerUnit"/>!).
+        /// </summary>
+        int StackLimit { get; }
+    }
+}

--- a/OctoAwesome/OctoAwesome/IItemDefinition.cs
+++ b/OctoAwesome/OctoAwesome/IItemDefinition.cs
@@ -5,14 +5,8 @@ namespace OctoAwesome
     /// <summary>
     /// Interface für die Definition eînes Items
     /// </summary>
-    public interface IItemDefinition : IDefinition
+    public interface IItemDefinition : IDefinition, IInventoryableDefinition
     {
-        /// <summary>
-        /// Gibt an, wie viele dieses Items im Inventar in einem Slot gestapelt werden können
-        /// </summary>
-        [Obsolete]
-        int StackLimit { get; }
-
         /*/// <summary>
         /// Liefert die Physikalischen Paramerter, wie härte, dichte und bruchzähigkeit
         /// </summary>

--- a/OctoAwesome/OctoAwesome/InventorySlot.cs
+++ b/OctoAwesome/OctoAwesome/InventorySlot.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Das Item das in dem Slot ist.
         /// </summary>
-        public IDefinition Definition { get; set; }
+        public IInventoryableDefinition Definition { get; set; }
 
         /// <summary>
         /// Volumen des Elementes <see cref="Definition"/> in diesem Slot in dm³.

--- a/OctoAwesome/OctoAwesome/OctoAwesome.csproj
+++ b/OctoAwesome/OctoAwesome/OctoAwesome.csproj
@@ -90,6 +90,7 @@
     <Compile Include="IEntityList.cs" />
     <Compile Include="IExtensionLoader.cs" />
     <Compile Include="IExtensionResolver.cs" />
+    <Compile Include="IInventoryableDefinition.cs" />
     <Compile Include="IPersistenceManager.cs" />
     <Compile Include="IClimateMap.cs" />
     <Compile Include="IDefinitionManager.cs" />
@@ -135,7 +136,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-</Target>
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Ziel dieses PR ist das Zentralisieren von Methoden zum Manipulieren des Inventars. Bisher waren diese (teilweise sehr fehlerbehaftet, vgl. #155  #193) an den jeweiligen Stellen der Manipulation implementiert. 

Jetzt sind sie in den entsprechenden `EntityComponents` vorhanden, die auch die Daten halten: `ToolBarComponent` und `InventoryComponent`. Die beiden oben genannten, das Inventar/die Toolbar betreffenden Issues wurden gefixt.

Zur Vereintheitlichung wurde ein neues Interface `IInventoryableDefinition` eingeführt, das für das Inventar benötigte Informationen enthält (Volumen, Limits). Diese waren bisher nur in den Spezialisierungen enthalten und waren nicht zugreifbar und damit nicht in den Manipulationsmethoden nicht erreichbar (erschwerte #193).

fixes #155, #193, #210