### PR TITLE
Use gravity constant from planet

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
@@ -22,10 +22,15 @@ namespace OctoAwesome.Basics
         /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks</param>
         /// <param name="generator">Instanz des Map-Generators</param>
         /// <param name="seed">Seed des Zufallsgenerators</param>
-        /// <param name="gravity">Die Gravitationskonstante des neuen Planeten.</param>
-        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed, float gravity)
-            : base(id, universe, size, seed, gravity)
+        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed)
+            : base(id, universe, size, seed)
         {
+            // Berechnung der Gravitation auf Basis des Newton'schen Grundgesetzes und
+            // der Annahme einer Kugel mit gleicher Oberfläche wie der rechteckige Planet.
+            // Die Gravitationskonstante ist absichtlich so "groß", vgl. Issue #220
+            var radius = Math.Sqrt((Size.X * Size.Y) / (16 * Math.PI));
+            Gravity = (float)((4f / 3f) * Math.PI * 6.67e-7 * 5510 * radius);
+
             Initalize();
         }
 

--- a/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
@@ -22,8 +22,9 @@ namespace OctoAwesome.Basics
         /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks</param>
         /// <param name="generator">Instanz des Map-Generators</param>
         /// <param name="seed">Seed des Zufallsgenerators</param>
-        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed)
-            : base(id, universe, size, seed)
+        /// <param name="gravity">Die Gravitationskonstante des neuen Planeten.</param>
+        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed, float gravity)
+            : base(id, universe, size, seed, gravity)
         {
             Initalize();
         }

--- a/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ComplexPlanet.cs
@@ -6,6 +6,9 @@ namespace OctoAwesome.Basics
 {
     public class ComplexPlanet : Planet
     {
+        // Die Gravitationskonstante ist absichtlich so "groß", vgl. Issue #220
+        private const double GravitationalConstant = 6.67e-7;
+
         public int HEIGHTMAPDETAILS = 8;
 
         public float[,] Heightmap { get; private set; }
@@ -22,14 +25,14 @@ namespace OctoAwesome.Basics
         /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks</param>
         /// <param name="generator">Instanz des Map-Generators</param>
         /// <param name="seed">Seed des Zufallsgenerators</param>
-        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed)
+        /// <param name="averageDensity">Durchschnittliche Dichte des Planeten zur Berechnung der Gravitation in kg/m³. Erd- und Standardwert: 5510</param>
+        public ComplexPlanet(int id, Guid universe, Index3 size, IMapGenerator generator, int seed, int averageDensity = 5510)
             : base(id, universe, size, seed)
         {
             // Berechnung der Gravitation auf Basis des Newton'schen Grundgesetzes und
             // der Annahme einer Kugel mit gleicher Oberfläche wie der rechteckige Planet.
-            // Die Gravitationskonstante ist absichtlich so "groß", vgl. Issue #220
             var radius = Math.Sqrt((Size.X * Size.Y) / (16 * Math.PI));
-            Gravity = (float)((4f / 3f) * Math.PI * 6.67e-7 * 5510 * radius);
+            Gravity = (float)((4f / 3f) * Math.PI * GravitationalConstant * averageDensity * radius);
 
             Initalize();
         }

--- a/OctoAwesome/OctoAwesome.Basics/ComplexPlanetGenerator.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ComplexPlanetGenerator.cs
@@ -11,7 +11,7 @@ namespace OctoAwesome.Basics
         public IPlanet GeneratePlanet(Guid universe, int id, int seed)
         {
             Index3 size = new Index3(12, 12, 3);
-            ComplexPlanet planet = new ComplexPlanet(id, universe, size, this, seed)
+            ComplexPlanet planet = new ComplexPlanet(id, universe, size, this, seed, 10) //TODO: Remove hardcoded gravity
             {
                 Generator = this
             };

--- a/OctoAwesome/OctoAwesome.Basics/ComplexPlanetGenerator.cs
+++ b/OctoAwesome/OctoAwesome.Basics/ComplexPlanetGenerator.cs
@@ -11,7 +11,8 @@ namespace OctoAwesome.Basics
         public IPlanet GeneratePlanet(Guid universe, int id, int seed)
         {
             Index3 size = new Index3(12, 12, 3);
-            ComplexPlanet planet = new ComplexPlanet(id, universe, size, this, seed, 10) //TODO: Remove hardcoded gravity
+            //TODO: Ist es gewollt, das hier der Generator zwei mal reingegeben wird?
+            ComplexPlanet planet = new ComplexPlanet(id, universe, size, this, seed)
             {
                 Generator = this
             };

--- a/OctoAwesome/OctoAwesome.Basics/DebugMapGenerator.cs
+++ b/OctoAwesome/OctoAwesome.Basics/DebugMapGenerator.cs
@@ -12,7 +12,7 @@ namespace OctoAwesome.Basics
     {
         public IPlanet GeneratePlanet(Guid universe, int id, int seed)
         {
-            Planet planet = new Planet(id, universe, new Index3(4, 4, 3), seed);
+            Planet planet = new Planet(id, universe, new Index3(4, 4, 3), seed, 10);
             planet.Generator = this;
             return planet;
         }
@@ -65,7 +65,7 @@ namespace OctoAwesome.Basics
             return planet;
         }
 
-        
+
 
         public IChunkColumn GenerateColumn(Stream stream, IDefinitionManager definitionManager, int planetId, Index2 index)
         {

--- a/OctoAwesome/OctoAwesome.Basics/DebugMapGenerator.cs
+++ b/OctoAwesome/OctoAwesome.Basics/DebugMapGenerator.cs
@@ -12,7 +12,7 @@ namespace OctoAwesome.Basics
     {
         public IPlanet GeneratePlanet(Guid universe, int id, int seed)
         {
-            Planet planet = new Planet(id, universe, new Index3(4, 4, 3), seed, 10);
+            Planet planet = new Planet(id, universe, new Index3(4, 4, 3), seed);
             planet.Generator = this;
             return planet;
         }

--- a/OctoAwesome/OctoAwesome.Basics/SimulationComponents/NewtonGravitatorComponent.cs
+++ b/OctoAwesome/OctoAwesome.Basics/SimulationComponents/NewtonGravitatorComponent.cs
@@ -9,7 +9,7 @@ using OctoAwesome.EntityComponents;
 
 namespace OctoAwesome.Basics.SimulationComponents
 {
-    [EntityFilter(typeof(GravityComponent),typeof(BodyComponent))]
+    [EntityFilter(typeof(GravityComponent), typeof(BodyComponent))]
     public class NewtonGravitatorComponent : SimulationComponent
     {
         class GravityEntity
@@ -25,7 +25,17 @@ namespace OctoAwesome.Basics.SimulationComponents
         {
             foreach (var entity in entities)
             {
-                entity.GravityComponent.Force = new Vector3(0, 0, -entity.BodyComponent.Mass * 10);
+                var gravity = 10f;
+
+                var positionComponent = entity.Entity.Components.GetComponent<PositionComponent>();
+                if (positionComponent != null)
+                {
+                    var id = positionComponent.Position.Planet;
+                    var planet = entity.Entity.Simulation.ResourceManager.GetPlanet(id);
+                    gravity = planet.Gravity;
+                }
+
+                entity.GravityComponent.Force = new Vector3(0, 0, -entity.BodyComponent.Mass * gravity);
             }
         }
 

--- a/OctoAwesome/OctoAwesome.Client/Controls/DebugControl.cs
+++ b/OctoAwesome/OctoAwesome.Client/Controls/DebugControl.cs
@@ -27,7 +27,7 @@ namespace OctoAwesome.Client.Controls
         private readonly ScreenComponent manager;
 
         StackPanel leftView, rightView;
-        Label devText, position, rotation, fps, box, controlInfo, loadedChunks, loadedTextures, activeTool, toolCount, loadedInfo, flyInfo, temperatureInfo, precipitationInfo;
+        Label devText, position, rotation, fps, box, controlInfo, loadedChunks, loadedTextures, activeTool, toolCount, loadedInfo, flyInfo, temperatureInfo, precipitationInfo, gravityInfo;
 
         public DebugControl(ScreenComponent screenManager)
             : base(screenManager)
@@ -40,7 +40,7 @@ namespace OctoAwesome.Client.Controls
             //Brush for Debug Background
             BorderBrush bg = new BorderBrush(Color.Black * 0.2f);
 
-            //The left side of the Screen 
+            //The left side of the Screen
             leftView = new StackPanel(ScreenManager)
             {
                 Background = bg,
@@ -81,12 +81,15 @@ namespace OctoAwesome.Client.Controls
 
             controlInfo = new Label(ScreenManager);
             leftView.Controls.Add(controlInfo);
-          
+
             temperatureInfo = new Label(ScreenManager);
             rightView.Controls.Add(temperatureInfo);
 
             precipitationInfo = new Label(ScreenManager);
             rightView.Controls.Add(precipitationInfo);
+
+            gravityInfo = new Label(ScreenManager);
+            rightView.Controls.Add(gravityInfo);
 
             activeTool = new Label(ScreenManager);
             rightView.Controls.Add(activeTool);
@@ -168,8 +171,8 @@ namespace OctoAwesome.Client.Controls
             fps.Text = fpsString;
 
             //Draw Loaded Chunks
-            loadedChunks.Text = string.Format("{0}: {1}/{2}", 
-                Languages.OctoClient.LoadedChunks, 
+            loadedChunks.Text = string.Format("{0}: {1}/{2}",
+                Languages.OctoClient.LoadedChunks,
                 manager.Game.ResourceManager.GlobalChunkCache.DirtyChunkColumn,
                 manager.Game.ResourceManager.GlobalChunkCache.LoadedChunkColumns);
 
@@ -183,11 +186,11 @@ namespace OctoAwesome.Client.Controls
 
             //Additional Play Information
 
-            ////Active Tool
-            //if (Player.ActorHost.ActiveTool != null)
-            //    activeTool.Text = Languages.OctoClient.ActiveItemTool + ": " + Player.ActorHost.ActiveTool.Definition.Name + " | " + Array.FindIndex(Player.ActorHost.Player.Tools, (i => i.Definition == Player.ActorHost.ActiveTool.Definition));
+            //Active Tool
+            if (Player.Toolbar.ActiveTool != null)
+                activeTool.Text = Languages.OctoClient.ActiveItemTool + ": " + Player.Toolbar.ActiveTool.Definition.Name + " | " + Player.Toolbar.GetSlotIndex(Player.Toolbar.ActiveTool);
 
-            // toolCount.Text = Languages.OctoClient.ToolCount + ": " + Player.ActorHost.Player.Tools.Length;
+            toolCount.Text = Languages.OctoClient.ToolCount + ": " + Player.Toolbar.Tools.Count(slot => slot != null);
 
             ////Fly Info
             //if (Player.ActorHost.Player.FlyMode) flyInfo.Text = Languages.OctoClient.FlymodeEnabled;
@@ -199,6 +202,9 @@ namespace OctoAwesome.Client.Controls
 
             // Precipitation Info
             precipitationInfo.Text = "Precipitation: " + planet.ClimateMap.GetPrecipitation(Player.Position.Position.GlobalBlockIndex);
+
+            // Gravity Info
+            gravityInfo.Text = "Gravity" + ": " + planet.Gravity;
 
             //Draw Box Information
             if (Player.SelectedBox.HasValue)

--- a/OctoAwesome/OctoAwesome.Tests/TestPlanet.cs
+++ b/OctoAwesome/OctoAwesome.Tests/TestPlanet.cs
@@ -15,35 +15,20 @@ namespace OctoAwesome.Tests
             Size = size;
         }
 
-        public IClimateMap ClimateMap
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public IClimateMap ClimateMap => throw new NotImplementedException();
 
-        public IMapGenerator Generator
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public IMapGenerator Generator => throw new NotImplementedException();
 
         public int Id { get; private set; }
 
-        public int Seed
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public int Seed => throw new NotImplementedException();
 
         public Index3 Size { get; private set; }
 
         public Guid Universe { get; private set; }
+
+        public float Gravity => throw new NotImplementedException();
+
         IMapGenerator IPlanet.Generator { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public void Deserialize(Stream stream)

--- a/OctoAwesome/OctoAwesome/Coordinate.cs
+++ b/OctoAwesome/OctoAwesome/Coordinate.cs
@@ -199,16 +199,14 @@ namespace OctoAwesome
         /// <param name="i1"></param>
         /// <param name="i2"></param>
         /// <returns>Das Ergebnis der Addition</returns>
-        public static Coordinate operator +(Coordinate i1, Vector3 i2) 
+        public static Coordinate operator +(Coordinate i1, Vector3 i2)
             => new Coordinate(i1.Planet, i1.block, i1.position + i2);
 
         /// <summary>
         /// Stellt die Coordinate-Instanz als string dar.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $@"({ Planet }/
-                    {(block.X + position.X).ToString("0.00")}/
-                    {(block.Y + position.Y).ToString("0.00")}/
-                    {(block.Z + position.Z).ToString("0.00")})";
+        public override string ToString()
+            => $@"({ Planet }/{(block.X + position.X).ToString("0.00")}/{(block.Y + position.Y).ToString("0.00")}/{(block.Z + position.Z).ToString("0.00")})";
     }
 }

--- a/OctoAwesome/OctoAwesome/IPlanet.cs
+++ b/OctoAwesome/OctoAwesome/IPlanet.cs
@@ -29,6 +29,11 @@ namespace OctoAwesome
         Index3 Size { get; }
 
         /// <summary>
+        /// Gravitation des Planeten.
+        /// </summary>
+        float Gravity { get; }
+
+        /// <summary>
         /// Die Klimakarte des Planeten
         /// </summary>
         IClimateMap ClimateMap { get; }

--- a/OctoAwesome/OctoAwesome/Planet.cs
+++ b/OctoAwesome/OctoAwesome/Planet.cs
@@ -45,13 +45,14 @@ namespace OctoAwesome
         public IMapGenerator Generator { get; set; }
 
         /// <summary>
-        /// Initialisierung des Planeten
+        /// Initialisierung des Planeten.
         /// </summary>
-        /// <param name="id">ID des Planeten</param>
-        /// <param name="universe">ID des Universums</param>
-        /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks</param>
-        /// <param name="seed">Seed des Zufallsgenerators</param>
-        public Planet(int id, Guid universe, Index3 size, int seed)
+        /// <param name="id">ID des Planeten.</param>
+        /// <param name="universe">ID des Universums.</param>
+        /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks.</param>
+        /// <param name="seed">Seed des Zufallsgenerators.</param>
+        /// <param name="gravity">Die Gravitationskonstante des neuen Planeten.</param>
+        public Planet(int id, Guid universe, Index3 size, int seed, float gravity)
         {
             Id = id;
             Universe = universe;
@@ -60,6 +61,7 @@ namespace OctoAwesome
                 (int)Math.Pow(2, size.Y),
                 (int)Math.Pow(2, size.Z));
             Seed = seed;
+            Gravity = gravity;
         }
 
         /// <summary>

--- a/OctoAwesome/OctoAwesome/Planet.cs
+++ b/OctoAwesome/OctoAwesome/Planet.cs
@@ -37,7 +37,7 @@ namespace OctoAwesome
         /// <summary>
         /// Gravitation des Planeten.
         /// </summary>
-        public float Gravity { get; private set; }
+        public float Gravity { get; protected set; }
 
         /// <summary>
         /// Der Generator des Planeten.
@@ -51,8 +51,7 @@ namespace OctoAwesome
         /// <param name="universe">ID des Universums.</param>
         /// <param name="size">Größe des Planeten in Zweierpotenzen Chunks.</param>
         /// <param name="seed">Seed des Zufallsgenerators.</param>
-        /// <param name="gravity">Die Gravitationskonstante des neuen Planeten.</param>
-        public Planet(int id, Guid universe, Index3 size, int seed, float gravity)
+        public Planet(int id, Guid universe, Index3 size, int seed)
         {
             Id = id;
             Universe = universe;
@@ -61,7 +60,6 @@ namespace OctoAwesome
                 (int)Math.Pow(2, size.Y),
                 (int)Math.Pow(2, size.Z));
             Seed = seed;
-            Gravity = gravity;
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #220 

Die Schnittstelle `IPlanet` bekommt das schon länger im `Planet` vorhandene Property `Gravity`. In der entsprechenden Gravitator-Komponente wird dann auch die Angabe aus dem Planet verwendet.

Daneben wird die Gravitation anhand der Planetengröße berechnet. Unsere Derzeit verwendete Planetengöße 2¹² x 2¹² Blöcke entspricht dabei gravitativ annähernd der Erde.