### PR TITLE
Fix texture rotation & offsets. Re-enable oriented block placement

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
+++ b/OctoAwesome/OctoAwesome.Basics/SimulationComponents/BlockInteractionComponent.cs
@@ -102,6 +102,7 @@ namespace OctoAwesome.Basics.SimulationComponents
                             if (inventory.RemoveUnit(toolbar.ActiveTool))
                             {
                                 entity.Cache.SetBlock(idx, simulation.ResourceManager.DefinitionManager.GetDefinitionIndex(definition));
+                                entity.Cache.SetBlockMeta(idx, (int)controller.ApplySide);
                                 if (toolbar.ActiveTool.Amount <= 0)
                                     toolbar.RemoveSlot(toolbar.ActiveTool);
                             }

--- a/OctoAwesome/OctoAwesome.Client/Components/ChunkRenderer.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/ChunkRenderer.cs
@@ -76,20 +76,20 @@ namespace OctoAwesome.Client.Components
                 chunk.Changed -= OnChunkChanged;
                 chunk = null;
             }
-           
+
             loaded = false;
             NeedsUpdate = true;
         }
 
         public bool NeedsUpdate = false;
-        
+
 
         private void OnChunkChanged(IChunk c, int n)
         {
             NeedsUpdate = true;
             _sceneControl.Enqueue(this);
         }
-        
+
         public void Draw(Matrix view, Matrix projection, Index3 shift)
         {
             if (!loaded)
@@ -144,7 +144,7 @@ namespace OctoAwesome.Client.Components
             }
 
         }
-        
+
         private int ChangeStart = -1;
 
         public bool RegenerateVertexBuffer()
@@ -222,14 +222,18 @@ namespace OctoAwesome.Client.Components
                         ushort topBlock = _manager.GetBlock((ChunkPosition.Value * Chunk.CHUNKSIZE) + new Index3(x, y, z + 1));
                         IBlockDefinition topBlockDefintion = (IBlockDefinition)definitionManager.GetDefinitionByIndex(topBlock);
 
+                        var globalX = x + chunk.Index.X * Chunk.CHUNKSIZE_X;
+                        var globalY = y + chunk.Index.Y * Chunk.CHUNKSIZE_Y;
+                        var globalZ = z + chunk.Index.Z * Chunk.CHUNKSIZE_Z;
+
                         // Top
                         if (topBlock == 0 || (!topBlockDefintion.IsSolidWall(Wall.Bottom) && topBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)) / textureColumns) * textureWidth) + textureGap);
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Top, _manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Top, _manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -237,28 +241,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 0, y + 1, z + 1),
                                     new Vector3(0, 0, 1),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 1, z + 1),
                                     new Vector3(0, 0, 1),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 0, z + 1),
                                     new Vector3(0, 0, 1),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 1),
                                     new Vector3(0, 0, 1),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Top,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -276,10 +280,10 @@ namespace OctoAwesome.Client.Components
                         if (bottomBlock == 0 || (!bottomBlockDefintion.IsSolidWall (Wall.Top) && bottomBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom, _manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom, _manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom, _manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom, _manager, globalX, globalY, globalZ)) / textureColumns) * textureWidth) + textureGap);
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Bottom,_manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Bottom,_manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -287,28 +291,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 1, y + 1, z + 0),
                                     new Vector3(0, 0, -1),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 1, z + 0),
                                     new Vector3(0, 0, -1),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 0),
                                     new Vector3(0, 0, -1),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 0, z + 0),
                                     new Vector3(0, 0, -1),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Bottom,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -325,10 +329,10 @@ namespace OctoAwesome.Client.Components
                         if (southBlock == 0 || (!southBlockDefintion.IsSolidWall(Wall.Front) && southBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)) / textureColumns) * textureWidth) + textureGap);
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Front, _manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Front, _manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -336,28 +340,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 0, y + 1, z + 0),
                                     new Vector3(0, 1, 0),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 1, z + 0),
                                     new Vector3(0, 1, 0),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 1, z + 1),
                                     new Vector3(0, 1, 0),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 1, z + 1),
                                     new Vector3(0, 1, 0),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Front,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -374,10 +378,10 @@ namespace OctoAwesome.Client.Components
                         if (northBlock == 0 || (!northBlockDefintion.IsSolidWall (Wall.Back) && northBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ) / textureColumns) * textureWidth) + textureGap));
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Back, _manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Back, _manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -385,28 +389,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 0, y + 0, z + 1),
                                     new Vector3(0, -1, 0),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 1),
                                     new Vector3(0, -1, 0),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 0, z + 0),
                                     new Vector3(0, -1, 0),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 0),
                                     new Vector3(0, -1, 0),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Back,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -423,11 +427,11 @@ namespace OctoAwesome.Client.Components
                         if (westBlock == 0 || (!westBlockDefintion.IsSolidWall(Wall.Right) && westBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)) / textureColumns) * textureWidth) + textureGap);
 
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Left, _manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Left, _manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -435,28 +439,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 0, y + 1, z + 0),
                                     new Vector3(-1, 0, 0),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 1, z + 1),
                                     new Vector3(-1, 0, 0),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 0, z + 0),
                                     new Vector3(-1, 0, 0),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 0, y + 0, z + 1),
                                     new Vector3(-1, 0, 0),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Left,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -473,11 +477,11 @@ namespace OctoAwesome.Client.Components
                         if (eastBlock == 0 || (!eastBlockDefintion.IsSolidWall(Wall.Left) && eastBlock != block))
                         {
                             textureOffset = new Vector2(
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)) % textureColumns) * textureWidth) + textureGap,
-                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)) / textureColumns) * textureWidth) + textureGap);
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)) % textureColumns) * textureWidth) + textureGap,
+                                (((textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)) / textureColumns) * textureWidth) + textureGap);
 
 
-                            int rotation = -blockDefinition.GetTextureRotation(Wall.Right,_manager, x, y, z);
+                            int rotation = -blockDefinition.GetTextureRotation(Wall.Right,_manager, globalX, globalY, globalZ);
 
                             int localOffset = vertices.Count;
                             vertices.Add(
@@ -485,28 +489,28 @@ namespace OctoAwesome.Client.Components
                                     new Vector3(x + 1, y + 1, z + 1),
                                     new Vector3(1, 0, 0),
                                     uvOffsets[(5 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 1, z + 0),
                                     new Vector3(1, 0, 0),
                                     uvOffsets[(6 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 1),
                                     new Vector3(1, 0, 0),
                                     uvOffsets[(4 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)),
                                     0));
                             vertices.Add(
                                 new VertexPositionNormalTextureLight(
                                     new Vector3(x + 1, y + 0, z + 0),
                                     new Vector3(1, 0, 0),
                                     uvOffsets[(7 + rotation) % 4],
-                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, x, y, z)),
+                                    (byte) (textureIndex + blockDefinition.GetTextureIndex(Wall.Right,_manager, globalX, globalY, globalZ)),
                                     0));
                             index.Add(localOffset + 0);
                             index.Add(localOffset + 1);
@@ -521,7 +525,7 @@ namespace OctoAwesome.Client.Components
 
             vertexCount = vertices.Count;
             indexCount = index.Count;
-            
+
 
             if (vertexCount > 0)
             {


### PR DESCRIPTION
Jetzt werden die korrekten globalen IDs verwendet