### PR TITLE
Kompilierungsprobleme in den Testprojekten behoben

### DIFF
--- a/OctoAwesome/OctoAwesome.Network.Tests/ServerTests.cs
+++ b/OctoAwesome/OctoAwesome.Network.Tests/ServerTests.cs
@@ -16,7 +16,7 @@ namespace OctoAwesome.Network.Tests
         public void NewServerTest()
         {
             var server = new Server();
-            server.Start(IPAddress.Any, 44444);
+            server.Start(new IPEndPoint(IPAddress.Any, 44444));
         }
 
         [TestMethod]
@@ -24,7 +24,7 @@ namespace OctoAwesome.Network.Tests
         {
             var resetEvent = new ManualResetEvent(false);
             var server = new Server();
-            server.Start(IPAddress.Any, 44444);
+            server.Start(new IPEndPoint(IPAddress.Any, 44444));
             var testClient = new TcpClient("localhost", 44444);
 
             for (int i = 0; i < 201; i++)
@@ -44,7 +44,7 @@ namespace OctoAwesome.Network.Tests
             var resetEvent = new ManualResetEvent(false);
             var wait = new ManualResetEvent(false);
             var server = new Server();
-            server.Start(IPAddress.Any, 44444);
+            server.Start(new IPEndPoint(IPAddress.Any, 44444));
             server.OnClientConnected += (s, e) =>
             {
                 //server.Clients.TryPeek(out Client client);

--- a/OctoAwesome/OctoAwesome.Tests/TestGlobalCache.cs
+++ b/OctoAwesome/OctoAwesome.Tests/TestGlobalCache.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using OctoAwesome.Notifications;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -80,6 +81,36 @@ namespace OctoAwesome.Tests
         }
 
         public void AfterSimulationUpdate(Simulation simulation)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnUpdate(SerializableNotification notification)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Update(SerializableNotification notification)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void InsertUpdateHub(IUpdateHub updateHub)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnNext(Notification value)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Hallo zusammen, ich habe in den Projekten `OctoAwesome.Network.Tests` und `OctoAwesome.Tests` Fehler behoben damit man `develop` wieder erfolgreich bauen kann.
- In `OctoAwesome.Network.Tests.ServerTests` den Aufruf von `server.Start(IPAddress.Any, 44444)` zu `server.Start(new IPEndPoint(IPAddress.Any, 44444))` umgeändert
- In `OctoAwesome.Tests.TestGlobalCache` die fehlenden Schnittstellenmember von `IGlobalChunkCache` mit `throw new NotImplementedException()` implementiert