### PR TITLE
Reworked Tag saving to use span instead of returning byte array

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/SimulationComponents/MoveComponent.cs
+++ b/OctoAwesome/OctoAwesome.Basics/SimulationComponents/MoveComponent.cs
@@ -144,6 +144,7 @@ namespace OctoAwesome.Basics.SimulationComponents
                             {
                                 if (!CollisionPlane.Intersect(blockPlane, playerPlane))
                                     continue;
+                                    
                                 var distance = CollisionPlane.GetDistance(blockPlane, playerPlane);
 
                                 if (!CollisionPlane.CheckDistance(distance, move))

--- a/OctoAwesome/OctoAwesome.Client/Components/ChunkRenderer.cs
+++ b/OctoAwesome/OctoAwesome.Client/Components/ChunkRenderer.cs
@@ -390,12 +390,10 @@ namespace OctoAwesome.Client.Components
             if (getFromManager)
             {
 
-                //IChunk chunk;
                 for (int zOffset = -1; zOffset <= 1; zOffset++)
                     for (int yOffset = -1; yOffset <= 1; yOffset++)
                         for (int xOffset = -1; xOffset <= 1; xOffset++)
                         {
-                            //chunk = chunks[GetIndex(IsBorder(z) * OutsiteOfChunkBorderInDirection(z, zOffset), IsBorder(y) * OutsiteOfChunkBorderInDirection(y, yOffset), IsBorder(x) * OutsiteOfChunkBorderInDirection(x, xOffset))];
                             blocks[GetIndex(zOffset, yOffset, xOffset)] = manager.GetBlock((chunkPosition * Chunk.CHUNKSIZE) + new Index3(x + xOffset, y + yOffset, z + zOffset));
                         }
             }

--- a/OctoAwesome/OctoAwesome.Client/Controls/DebugControl.cs
+++ b/OctoAwesome/OctoAwesome.Client/Controls/DebugControl.cs
@@ -38,10 +38,10 @@ namespace OctoAwesome.Client.Controls
             Player = screenManager.Player;
             manager = screenManager;
             assets = screenManager.Game.Assets;
+            Background = new SolidColorBrush(Color.Transparent);
 
             //Brush for Debug Background
             BorderBrush bg = new BorderBrush(Color.Black * 0.2f);
-
             //The left side of the Screen
             leftView = new StackPanel(ScreenManager)
             {

--- a/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
@@ -92,10 +92,10 @@ namespace OctoAwesome.Client.Screens
 
         protected override void OnUpdate(GameTime gameTime)
         {
-            if (pressedMoveUp) Manager.Player.MoveInput += new Vector2(0f, 1f);
-            if (pressedMoveLeft) Manager.Player.MoveInput += new Vector2(-1f, 0f);
-            if (pressedMoveDown) Manager.Player.MoveInput += new Vector2(0f, -1f);
-            if (pressedMoveRight) Manager.Player.MoveInput += new Vector2(1f, 0f);
+            if (pressedMoveUp) Manager.Player.MoveInput += new Vector2(0f, 10f);
+            if (pressedMoveLeft) Manager.Player.MoveInput += new Vector2(-10f, 0f);
+            if (pressedMoveDown) Manager.Player.MoveInput += new Vector2(0f, -10f);
+            if (pressedMoveRight) Manager.Player.MoveInput += new Vector2(10f, 0f);
             if (pressedHeadUp) Manager.Player.HeadInput += new Vector2(0f, 1f);
             if (pressedHeadDown) Manager.Player.HeadInput += new Vector2(0f, -1f);
             if (pressedHeadLeft) Manager.Player.HeadInput += new Vector2(-1f, 0f);

--- a/OctoAwesome/OctoAwesome.Database/Defragmentation.cs
+++ b/OctoAwesome/OctoAwesome.Database/Defragmentation.cs
@@ -46,6 +46,7 @@ namespace OctoAwesome.Database
         {
             using (FileStream newKeyStoreFile = keyStoreFile.Open(FileMode.OpenOrCreate, FileAccess.Write, FileShare.None))
             {
+
                 foreach (Key<TTag> key in keyList)
                     newKeyStoreFile.Write(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
             }
@@ -64,21 +65,21 @@ namespace OctoAwesome.Database
 
                     if (key.IsEmpty)
                     {
-                        var intBuffer = new byte[sizeof(int)];
-                        if (currentValueStoreStream.Read(intBuffer, 0, sizeof(int)) == 0)
+                        Span<byte> intBuffer = stackalloc byte[sizeof(int)];
+                        if (currentValueStoreStream.Read(intBuffer) == 0)
                             break;
-                        var length = BitConverter.ToInt32(intBuffer, 0) - sizeof(int);
+                        var length = BitConverter.ToInt32(intBuffer) - sizeof(int);
                         if (length < 0)
                             throw new DataMisalignedException();
                         currentValueStoreStream.Seek(length, SeekOrigin.Current);
                     }
                     else
                     {
-                        var buffer = new byte[key.ValueLength];
-                        if (currentValueStoreStream.Read(buffer, 0, buffer.Length) == 0)
+                        Span<byte> buffer = stackalloc byte[key.ValueLength];
+                        if (currentValueStoreStream.Read(buffer) == 0)
                             break;
                         newValueStoreStream.Write(keyBuffer, 0, keyBuffer.Length);
-                        newValueStoreStream.Write(buffer, 0, buffer.Length);
+                        newValueStoreStream.Write(buffer);
                         yield return key;
                     }
                 } while (currentValueStoreStream.Position < currentValueStoreStream.Length);
@@ -98,10 +99,10 @@ namespace OctoAwesome.Database
 
                     if (key.IsEmpty)
                     {
-                        var intBuffer = new byte[sizeof(int)];
-                        if (fileStream.Read(intBuffer, 0, sizeof(int)) == 0)
+                        Span<byte> intBuffer = stackalloc byte[sizeof(int)];
+                        if (fileStream.Read(intBuffer) == 0)
                             break;
-                        length = BitConverter.ToInt32(intBuffer, 0) - sizeof(int);
+                        length = BitConverter.ToInt32(intBuffer) - sizeof(int);
                     }
                     else
                     {

--- a/OctoAwesome/OctoAwesome.Database/GuidTag.cs
+++ b/OctoAwesome/OctoAwesome.Database/GuidTag.cs
@@ -22,10 +22,10 @@ namespace OctoAwesome.Database
         public void FromBytes(byte[] array, int startIndex)
             => Tag = new Guid(array.Skip(startIndex).Take(Length).ToArray());
 
-        public override bool Equals(object obj) 
+        public override bool Equals(object obj)
             => obj is GuidTag<T> tag && Equals(tag);
 
-        public bool Equals(GuidTag<T> other) 
+        public bool Equals(GuidTag<T> other)
             => Length == other.Length && Tag.Equals(other.Tag);
 
         public override int GetHashCode()
@@ -34,6 +34,11 @@ namespace OctoAwesome.Database
             hashCode = hashCode * -1521134295 + Tag.GetHashCode();
             hashCode = hashCode * -1521134295 + Length.GetHashCode();
             return hashCode;
+        }
+
+        public void WriteBytes(Span<byte> span)
+        {
+            Tag.TryWriteBytes(span);
         }
 
         public static bool operator ==(GuidTag<T> left, GuidTag<T> right)

--- a/OctoAwesome/OctoAwesome.Database/ITag.cs
+++ b/OctoAwesome/OctoAwesome.Database/ITag.cs
@@ -11,5 +11,6 @@ namespace OctoAwesome.Database
         byte[] GetBytes();
 
         void FromBytes(byte[] array, int startIndex);
+        void WriteBytes(Span<byte> span);
     }
 }

--- a/OctoAwesome/OctoAwesome.Database/IdTag.cs
+++ b/OctoAwesome/OctoAwesome.Database/IdTag.cs
@@ -35,6 +35,11 @@ namespace OctoAwesome.Database
             return hashCode;
         }
 
+        public void WriteBytes(Span<byte> span)
+        {
+            BitConverter.TryWriteBytes(span, Tag);
+        }
+
         public static bool operator ==(IdTag<T> left, IdTag<T> right)
         {
             return left.Equals(right);

--- a/OctoAwesome/OctoAwesome.Database/Key.cs
+++ b/OctoAwesome/OctoAwesome.Database/Key.cs
@@ -66,6 +66,37 @@ namespace OctoAwesome.Database
             return byteArray;
         }
 
+        public void WriteBytes(Writer writer, long position, bool flush = false)
+        {
+            Span<byte> byteArray = stackalloc byte[KEY_SIZE];
+
+            BitConverter.TryWriteBytes(byteArray, Index);
+            BitConverter.TryWriteBytes(byteArray[sizeof(long)..], ValueLength);
+
+            if (Tag != null)
+                Tag.WriteBytes(byteArray[BASE_KEY_SIZE..(BASE_KEY_SIZE + Tag.Length)]);
+
+            if (flush)
+                    writer.WriteAndFlush(byteArray, position);
+            else
+                    writer.Write(byteArray, position);
+        }
+        public void WriteBytes(Writer writer, bool flush = false)
+        {
+            Span<byte> byteArray = stackalloc byte[KEY_SIZE];
+
+            BitConverter.TryWriteBytes(byteArray, Index);
+            BitConverter.TryWriteBytes(byteArray[sizeof(long)..], ValueLength);
+
+            if (Tag != null)
+                Tag.WriteBytes(byteArray[BASE_KEY_SIZE..(BASE_KEY_SIZE + Tag.Length)]);
+
+            if (flush)
+                    writer.WriteAndFlush(byteArray);
+            else
+                    writer.Write(byteArray);
+        }
+
         public static Key<TTag> FromBytes(byte[] array, int index)
         {
             var localIndex = BitConverter.ToInt64(array, index);

--- a/OctoAwesome/OctoAwesome.Database/Key.cs
+++ b/OctoAwesome/OctoAwesome.Database/Key.cs
@@ -73,7 +73,7 @@ namespace OctoAwesome.Database
             BitConverter.TryWriteBytes(byteArray, Index);
             BitConverter.TryWriteBytes(byteArray[sizeof(long)..], ValueLength);
 
-            if (Tag != null)
+            if (Tag is not null)
                 Tag.WriteBytes(byteArray[BASE_KEY_SIZE..(BASE_KEY_SIZE + Tag.Length)]);
 
             if (flush)

--- a/OctoAwesome/OctoAwesome.Database/KeyStore.cs
+++ b/OctoAwesome/OctoAwesome.Database/KeyStore.cs
@@ -63,7 +63,8 @@ namespace OctoAwesome.Database
         {
             var oldKey = keys[key.Tag];
             keys[key.Tag] = new Key<TTag>(key.Tag, key.Index, key.ValueLength, oldKey.Position);
-            writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE, oldKey.Position);
+            key.WriteBytes(writer, oldKey.Position, true);
+            //writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE, oldKey.Position);
         }
 
         internal bool Contains(TTag tag)
@@ -75,14 +76,17 @@ namespace OctoAwesome.Database
         {
             key = new Key<TTag>(key.Tag, key.Index, key.ValueLength, writer.ToEnd());
             keys.Add(key.Tag, key);
-            writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
+            //writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
+            key.WriteBytes(writer, writer.ToEnd(), true);
+
         }
 
         internal void Remove(TTag tag, out Key<TTag> key)
         {
             key = keys[tag];
             keys.Remove(tag);
-            writer.WriteAndFlush(Key<TTag>.Empty.GetBytes(), 0, Key<TTag>.KEY_SIZE, key.Position);
+            //writer.WriteAndFlush(Key<TTag>.Empty.GetBytes(), 0, Key<TTag>.KEY_SIZE, key.Position);
+            key.WriteBytes(writer, key.Position, true);
         }
 
         public void Dispose()

--- a/OctoAwesome/OctoAwesome.Database/KeyStore.cs
+++ b/OctoAwesome/OctoAwesome.Database/KeyStore.cs
@@ -64,7 +64,6 @@ namespace OctoAwesome.Database
             var oldKey = keys[key.Tag];
             keys[key.Tag] = new Key<TTag>(key.Tag, key.Index, key.ValueLength, oldKey.Position);
             key.WriteBytes(writer, oldKey.Position, true);
-            //writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE, oldKey.Position);
         }
 
         internal bool Contains(TTag tag)
@@ -76,7 +75,6 @@ namespace OctoAwesome.Database
         {
             key = new Key<TTag>(key.Tag, key.Index, key.ValueLength, writer.ToEnd());
             keys.Add(key.Tag, key);
-            //writer.WriteAndFlush(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
             key.WriteBytes(writer, writer.ToEnd(), true);
 
         }
@@ -85,7 +83,6 @@ namespace OctoAwesome.Database
         {
             key = keys[tag];
             keys.Remove(tag);
-            //writer.WriteAndFlush(Key<TTag>.Empty.GetBytes(), 0, Key<TTag>.KEY_SIZE, key.Position);
             key.WriteBytes(writer, key.Position, true);
         }
 

--- a/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
+++ b/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
@@ -7,12 +7,10 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
-    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
+++ b/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
@@ -7,10 +7,12 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OctoAwesome/OctoAwesome.Database/ValueStore.cs
+++ b/OctoAwesome/OctoAwesome.Database/ValueStore.cs
@@ -32,9 +32,11 @@ namespace OctoAwesome.Database
 
         internal Key<TTag> AddValue<TTag>(TTag tag, Value value) where TTag : ITag, new()
         {
+            
             var key = new Key<TTag>(tag, writer.ToEnd(), value.Content.Length);
             //TODO: Hash, Sync
-            writer.Write(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
+            key.WriteBytes(writer);
+            //writer.Write(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
             writer.WriteAndFlush(value.Content, 0, value.Content.Length);
             return key;
         }
@@ -56,7 +58,7 @@ namespace OctoAwesome.Database
 
         internal void Remove<TTag>(Key<TTag> key) where TTag : ITag, new()
         {
-            writer.Write(Key<TTag>.Empty.GetBytes(), 0, Key<TTag>.KEY_SIZE, key.Index);
+            Key<TTag>.Empty.WriteBytes(writer, key.Index);
             writer.WriteAndFlush(BitConverter.GetBytes(key.ValueLength), 0, sizeof(int), key.Index + Key<TTag>.KEY_SIZE);
         }
 

--- a/OctoAwesome/OctoAwesome.Database/ValueStore.cs
+++ b/OctoAwesome/OctoAwesome.Database/ValueStore.cs
@@ -36,7 +36,6 @@ namespace OctoAwesome.Database
             var key = new Key<TTag>(tag, writer.ToEnd(), value.Content.Length);
             //TODO: Hash, Sync
             key.WriteBytes(writer);
-            //writer.Write(key.GetBytes(), 0, Key<TTag>.KEY_SIZE);
             writer.WriteAndFlush(value.Content, 0, value.Content.Length);
             return key;
         }

--- a/OctoAwesome/OctoAwesome.Database/Writer.cs
+++ b/OctoAwesome/OctoAwesome.Database/Writer.cs
@@ -30,22 +30,41 @@ namespace OctoAwesome.Database
             fileStream = null;
         }
 
-        public void Write(byte[] data, int offset, int length)
-            => fileStream.Write(data, offset, length);
-        public void Write(byte[] data, int offset, int length, long position)
+        public void Write(ReadOnlySpan<byte> data)
+          => fileStream.Write(data);
+        public void Write(ReadOnlySpan<byte> data, long position)
         {
             fileStream.Seek(position, SeekOrigin.Begin);
-            Write(data, offset, length);
+            Write(data);
         }
 
-        public void WriteAndFlush(byte[] data, int offset, int length)
+        public void WriteAndFlush(ReadOnlySpan<byte> data)
         {
-            Write(data, offset, length);
+            Write(data);
             fileStream.Flush();
         }
-        public void WriteAndFlush(byte[] data, int offset, int length, long position)
+        public void WriteAndFlush(ReadOnlySpan<byte> data, long position)
         {
-            Write(data, offset, length, position);
+            Write(data, position);
+            fileStream.Flush();
+        }
+
+        public void Write(ReadOnlySpan<byte> data, int offset, int length)
+            => fileStream.Write(data[offset..(offset+length)]);
+        public void Write(ReadOnlySpan<byte> data, int offset, int length, long position)
+        {
+            fileStream.Seek(position, SeekOrigin.Begin);
+            Write(data[offset..(offset + length)]);
+        }
+
+        public void WriteAndFlush(ReadOnlySpan<byte> data, int offset, int length)
+        {
+            Write(data[offset..(offset + length)]);
+            fileStream.Flush();
+        }
+        public void WriteAndFlush(ReadOnlySpan<byte> data, int offset, int length, long position)
+        {
+            Write(data[offset..(offset + length)], position);
             fileStream.Flush();
         }
 

--- a/OctoAwesome/OctoAwesome/Chunk.cs
+++ b/OctoAwesome/OctoAwesome/Chunk.cs
@@ -290,8 +290,10 @@ namespace OctoAwesome
         {
             Index = position;
             Planet = planet;
+
             for (int i = 0; i < Blocks.Length; i++)
                 Blocks[i] = 0;
+                
             for (int i = 0; i < MetaData.Length; i++)
                 MetaData[i] = 0;
         }

--- a/OctoAwesome/OctoAwesome/Chunk.cs
+++ b/OctoAwesome/OctoAwesome/Chunk.cs
@@ -290,6 +290,10 @@ namespace OctoAwesome
         {
             Index = position;
             Planet = planet;
+            for (int i = 0; i < Blocks.Length; i++)
+                Blocks[i] = 0;
+            for (int i = 0; i < MetaData.Length; i++)
+                MetaData[i] = 0;
         }
 
         public void Init(IPool pool)

--- a/OctoAwesome/OctoAwesome/ChunkColumn.cs
+++ b/OctoAwesome/OctoAwesome/ChunkColumn.cs
@@ -355,10 +355,10 @@ namespace OctoAwesome
 
 
             // Phase 2 (Block Definitionen)
-            var types = new List<IDefinition>();
-            var map = new Dictionary<ushort, ushort>();
-
             int typecount = longIndex ? reader.ReadUInt16() : reader.ReadByte();
+            var types = new List<IDefinition>();
+            Span<ushort> map = stackalloc ushort[typecount];
+
 
             for (var i = 0; i < typecount; i++)
             {
@@ -367,13 +367,15 @@ namespace OctoAwesome
                 IDefinition blockDefinition = definitions.FirstOrDefault(d => d.GetType().FullName == typeName);
                 types.Add(blockDefinition);
 
-                map.Add((ushort)types.Count, (ushort)(Array.IndexOf(definitions, blockDefinition) + 1));
+                map[types.Count-1] = (ushort)(Array.IndexOf(definitions, blockDefinition) + 1);
             }
 
             // Phase 3 (Chunk Infos)
             for (var c = 0; c < Chunks.Length; c++)
             {
-                IChunk chunk = Chunks[c] = new Chunk(new Index3(Index, c), Planet);
+
+
+                IChunk chunk = Chunks[c] = chunkPool.Get(new Index3(Index, c), Planet);
                 chunk.Version = reader.ReadInt32();
                 chunk.Changed += OnChunkChanged;
                 chunk.SetColumn(this);
@@ -382,7 +384,7 @@ namespace OctoAwesome
                 {
                     var typeIndex = longIndex ? reader.ReadUInt16() : reader.ReadByte();
                     chunk.MetaData[i] = 0;
-                    if (typeIndex > 0)
+                    if (typeIndex-- > 0)
                     {
                         chunk.Blocks[i] = map[typeIndex];
 

--- a/OctoAwesome/OctoAwesome/ChunkColumn.cs
+++ b/OctoAwesome/OctoAwesome/ChunkColumn.cs
@@ -384,11 +384,13 @@ namespace OctoAwesome
                 {
                     var typeIndex = longIndex ? reader.ReadUInt16() : reader.ReadByte();
                     chunk.MetaData[i] = 0;
-                    if (typeIndex-- > 0)
+                    if (typeIndex > 0)
                     {
-                        chunk.Blocks[i] = map[typeIndex];
+                        var definitionIndex = map[typeIndex-1];
 
-                        var definition = (IBlockDefinition)DefinitionManager.GetBlockDefinitionByIndex(map[typeIndex]);
+                        chunk.Blocks[i] = definitionIndex;
+
+                        var definition = (IBlockDefinition)DefinitionManager.GetBlockDefinitionByIndex(definitionIndex);
 
                         if (definition.HasMetaData)
                             chunk.MetaData[i] = reader.ReadInt32();

--- a/OctoAwesome/OctoAwesome/ChunkColumn.cs
+++ b/OctoAwesome/OctoAwesome/ChunkColumn.cs
@@ -373,8 +373,6 @@ namespace OctoAwesome
             // Phase 3 (Chunk Infos)
             for (var c = 0; c < Chunks.Length; c++)
             {
-
-
                 IChunk chunk = Chunks[c] = chunkPool.Get(new Index3(Index, c), Planet);
                 chunk.Version = reader.ReadInt32();
                 chunk.Changed += OnChunkChanged;

--- a/OctoAwesome/OctoAwesome/Serialization/ChunkColumnDbContext.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/ChunkColumnDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using OctoAwesome.Database;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -18,7 +19,7 @@ namespace OctoAwesome.Serialization
         public override void AddOrUpdate(IChunkColumn value)
         {
             using (Database.Lock(Operation.Write))
-                Database.AddOrUpdate(new Index2Tag(value.Index), new Value(Serializer.SerializeCompressed(value)));
+                Database.AddOrUpdate(new Index2Tag(value.Index), new Value(Serializer.SerializeCompressed(value, 2048)));
         }
 
         public IChunkColumn Get(Index2 key)

--- a/OctoAwesome/OctoAwesome/Serialization/ChunkDiffTag.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/ChunkDiffTag.cs
@@ -34,12 +34,25 @@ namespace OctoAwesome.Serialization
         {
             var array = new byte[Length];
 
-            Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.X), 0, array, 0, sizeof(int));
-            Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Y), 0, array, sizeof(int), sizeof(int));
-            Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Z), 0, array, sizeof(int) * 2, sizeof(int));
-            Buffer.BlockCopy(BitConverter.GetBytes(FlatIndex), 0, array, sizeof(int) * 3, sizeof(int));
+            const int intSize = sizeof(int);
+            BitConverter.TryWriteBytes(array[0..(intSize * 1)], ChunkPositon.X);
+            BitConverter.TryWriteBytes(array[(intSize * 1)..(intSize * 2)], ChunkPositon.Y);
+            BitConverter.TryWriteBytes(array[(intSize * 2)..(intSize * 3)], ChunkPositon.Z);
+            BitConverter.TryWriteBytes(array[(intSize * 3)..(intSize * 4)], FlatIndex);
+            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.X), 0, array, 0, sizeof(int));
+            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Y), 0, array, sizeof(int), sizeof(int));
+            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Z), 0, array, sizeof(int) * 2, sizeof(int));
+            //Buffer.BlockCopy(BitConverter.GetBytes(FlatIndex), 0, array, sizeof(int) * 3, sizeof(int));
 
             return array;
+        }
+        public void WriteBytes(Span<byte> span)
+        {
+            const int intSize = sizeof(int);
+            BitConverter.TryWriteBytes(span[0..(intSize * 1)], ChunkPositon.X);
+            BitConverter.TryWriteBytes(span[(intSize * 1)..(intSize * 2)], ChunkPositon.Y);
+            BitConverter.TryWriteBytes(span[(intSize * 2)..(intSize * 3)], ChunkPositon.Z);
+            BitConverter.TryWriteBytes(span[(intSize * 3)..(intSize * 4)], FlatIndex);
         }
 
         public override bool Equals(object obj)

--- a/OctoAwesome/OctoAwesome/Serialization/ChunkDiffTag.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/ChunkDiffTag.cs
@@ -39,10 +39,6 @@ namespace OctoAwesome.Serialization
             BitConverter.TryWriteBytes(array[(intSize * 1)..(intSize * 2)], ChunkPositon.Y);
             BitConverter.TryWriteBytes(array[(intSize * 2)..(intSize * 3)], ChunkPositon.Z);
             BitConverter.TryWriteBytes(array[(intSize * 3)..(intSize * 4)], FlatIndex);
-            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.X), 0, array, 0, sizeof(int));
-            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Y), 0, array, sizeof(int), sizeof(int));
-            //Buffer.BlockCopy(BitConverter.GetBytes(ChunkPositon.Z), 0, array, sizeof(int) * 2, sizeof(int));
-            //Buffer.BlockCopy(BitConverter.GetBytes(FlatIndex), 0, array, sizeof(int) * 3, sizeof(int));
 
             return array;
         }

--- a/OctoAwesome/OctoAwesome/Serialization/Index2Tag.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/Index2Tag.cs
@@ -19,8 +19,10 @@ namespace OctoAwesome.Serialization
         public byte[] GetBytes()
         {
             var byteArray = new byte[Length];
-            Buffer.BlockCopy(BitConverter.GetBytes(Index.X), 0, byteArray, 0, sizeof(int));
-            Buffer.BlockCopy(BitConverter.GetBytes(Index.Y), 0, byteArray, sizeof(int), sizeof(int));
+            BitConverter.TryWriteBytes(byteArray[0..sizeof(int)], Index.X);
+            BitConverter.TryWriteBytes(byteArray[sizeof(int)..(sizeof(int)*2)], Index.Y);
+            //Buffer.BlockCopy(BitConverter.GetBytes(Index.X), 0, byteArray, 0, sizeof(int));
+            //Buffer.BlockCopy(BitConverter.GetBytes(Index.Y), 0, byteArray, sizeof(int), sizeof(int));
             return byteArray;
         }
 
@@ -36,6 +38,13 @@ namespace OctoAwesome.Serialization
             hashCode = hashCode * -1521134295 + Length.GetHashCode();
             hashCode = hashCode * -1521134295 + Index.GetHashCode();
             return hashCode;
+        }
+
+        public void WriteBytes(Span<byte> span)
+        {
+            BitConverter.TryWriteBytes(span[0..sizeof(int)], Index.X);
+            BitConverter.TryWriteBytes(span[sizeof(int)..(sizeof(int) * 2)], Index.Y);
+ 
         }
 
         public static bool operator ==(Index2Tag left, Index2Tag right) 

--- a/OctoAwesome/OctoAwesome/Serialization/Index2Tag.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/Index2Tag.cs
@@ -21,8 +21,6 @@ namespace OctoAwesome.Serialization
             var byteArray = new byte[Length];
             BitConverter.TryWriteBytes(byteArray[0..sizeof(int)], Index.X);
             BitConverter.TryWriteBytes(byteArray[sizeof(int)..(sizeof(int)*2)], Index.Y);
-            //Buffer.BlockCopy(BitConverter.GetBytes(Index.X), 0, byteArray, 0, sizeof(int));
-            //Buffer.BlockCopy(BitConverter.GetBytes(Index.Y), 0, byteArray, sizeof(int), sizeof(int));
             return byteArray;
         }
 
@@ -44,7 +42,6 @@ namespace OctoAwesome.Serialization
         {
             BitConverter.TryWriteBytes(span[0..sizeof(int)], Index.X);
             BitConverter.TryWriteBytes(span[sizeof(int)..(sizeof(int) * 2)], Index.Y);
- 
         }
 
         public static bool operator ==(Index2Tag left, Index2Tag right) 

--- a/OctoAwesome/OctoAwesome/Serialization/Index3Tag.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/Index3Tag.cs
@@ -1,4 +1,5 @@
 ﻿using OctoAwesome.Database;
+
 using System;
 using System.Security.Cryptography;
 
@@ -20,16 +21,18 @@ namespace OctoAwesome.Serialization
         public byte[] GetBytes()
         {
             var byteArray = new byte[Length];
+            const int intSize = sizeof(int);
+
             Buffer.BlockCopy(BitConverter.GetBytes(Index.X), 0, byteArray, 0, sizeof(int));
             Buffer.BlockCopy(BitConverter.GetBytes(Index.Y), 0, byteArray, sizeof(int), sizeof(int));
-            Buffer.BlockCopy(BitConverter.GetBytes(Index.Z), 0, byteArray, sizeof(int)+ sizeof(int), sizeof(int));
+            Buffer.BlockCopy(BitConverter.GetBytes(Index.Z), 0, byteArray, sizeof(int) + sizeof(int), sizeof(int));
             return byteArray;
         }
 
-        public override bool Equals(object obj) 
+        public override bool Equals(object obj)
             => obj is Index3Tag tag && Equals(tag);
 
-        public bool Equals(Index3Tag other) 
+        public bool Equals(Index3Tag other)
             => Length == other.Length && Index.Equals(other.Index);
 
         public override int GetHashCode()
@@ -40,10 +43,17 @@ namespace OctoAwesome.Serialization
             return hashCode;
         }
 
-        public static bool operator ==(Index3Tag left, Index3Tag right) 
+        public void WriteBytes(Span<byte> span)
+        {
+            BitConverter.TryWriteBytes(span, Index.X);
+            BitConverter.TryWriteBytes(span[sizeof(int)..], Index.Y);
+            BitConverter.TryWriteBytes(span[(sizeof(int) + sizeof(int))..], Index.Z);
+        }
+
+        public static bool operator ==(Index3Tag left, Index3Tag right)
             => left.Equals(right);
 
-        public static bool operator !=(Index3Tag left, Index3Tag right) 
+        public static bool operator !=(Index3Tag left, Index3Tag right)
             => !(left == right);
     }
 }

--- a/OctoAwesome/OctoAwesome/Serialization/Serializer.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/Serializer.cs
@@ -1,5 +1,7 @@
 ﻿using NLog.Internal;
+
 using OctoAwesome.Pooling;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -37,6 +39,27 @@ namespace OctoAwesome.Serialization
 
                     return ms.ToArray();
                 }
+            }
+        }
+
+        public static byte[] SerializeCompressed<T>(T obj, int capacity) where T : ISerializable
+        {
+            using (var stream = new MemoryStream(capacity))
+            using (var zip = new GZipStream(stream, CompressionMode.Compress))
+            using (var buff = new BufferedStream(zip))
+            {
+                using (var writer = new BinaryWriter(buff, Encoding.Default, true))
+                    obj.Serialize(writer);
+
+                return stream.ToArray();
+
+                //using (var ms = new MemoryStream())
+                //{
+                //    stream.Position = 0;
+                //    using (var zip = new GZipStream(ms, CompressionMode.Compress, true))
+                //        stream.CopyTo(zip);
+
+                //}
             }
         }
 

--- a/OctoAwesome/OctoAwesome/Serialization/Serializer.cs
+++ b/OctoAwesome/OctoAwesome/Serialization/Serializer.cs
@@ -52,14 +52,6 @@ namespace OctoAwesome.Serialization
                     obj.Serialize(writer);
 
                 return stream.ToArray();
-
-                //using (var ms = new MemoryStream())
-                //{
-                //    stream.Position = 0;
-                //    using (var zip = new GZipStream(ms, CompressionMode.Compress, true))
-                //        stream.CopyTo(zip);
-
-                //}
             }
         }
 

--- a/OctoAwesome/OctoAwesome/Startup.cs
+++ b/OctoAwesome/OctoAwesome/Startup.cs
@@ -35,6 +35,7 @@ namespace OctoAwesome
             typeContainer.Register<Pool<EntityNotification>, Pool<EntityNotification>>(InstanceBehaviour.Singleton);
             typeContainer.Register<IPool<PropertyChangedNotification>, Pool<PropertyChangedNotification>>(InstanceBehaviour.Singleton);
             typeContainer.Register<Pool<PropertyChangedNotification>, Pool<PropertyChangedNotification>>(InstanceBehaviour.Singleton);
+            typeContainer.Register<IPool<Chunk>, ChunkPool>(InstanceBehaviour.Singleton);
             typeContainer.Register<ChunkPool, ChunkPool>(InstanceBehaviour.Singleton);
             typeContainer.Register<IPool<BlockVolumeState>, Pool<BlockVolumeState>>(InstanceBehaviour.Singleton);
             typeContainer.Register<BlockCollectionService>(InstanceBehaviour.Singleton);

--- a/OctoAwesome/Tests/OctoAwesome.Database.Tests/KeyTests.cs
+++ b/OctoAwesome/Tests/OctoAwesome.Database.Tests/KeyTests.cs
@@ -26,6 +26,11 @@ namespace OctoAwesome.Database.Tests
             }
 
             public byte[] GetBytes() => Array.Empty<byte>();
+
+            public void WriteBytes(Span<byte> span)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/OctoAwesome/Tests/OctoAwesome.Database.Tests/KeyTests.cs
+++ b/OctoAwesome/Tests/OctoAwesome.Database.Tests/KeyTests.cs
@@ -29,7 +29,6 @@ namespace OctoAwesome.Database.Tests
 
             public void WriteBytes(Span<byte> span)
             {
-                throw new NotImplementedException();
             }
         }
     }


### PR DESCRIPTION
* to save on garbage collection of the arrays and because we know the size beforehand, so we can allocate it on the stack
* Use chunkpool, which was already implemented but not correctly used, because get and push was never called
* Removed linq from MoveComponent, which did create a class on the heap, even tho it wasn't required
* Made stackalloc array in Chunkrenderer to be saved in a span, so no unsafe context is needed
