### PR TITLE
Kleinere Lebensqualitäts(QOL) Verbesserungen

### DIFF
--- a/OctoAwesome/OctoAwesome.Basics/OctoAwesome.Basics.csproj
+++ b/OctoAwesome/OctoAwesome.Basics/OctoAwesome.Basics.csproj
@@ -3,75 +3,21 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>warnings</Nullable>
-    
-    <DocumentationFile>..\bin\Debug\OctoAwesome.Basics.XML</DocumentationFile>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="Assets\Definitions\Items\axe_iron.png" />
-    <None Remove="Assets\Definitions\Items\bucket.png" />
-    <None Remove="Assets\Definitions\Items\chest.png" />
-    <None Remove="Assets\Definitions\Items\hammer_iron.png" />
-    <None Remove="Assets\Definitions\Items\hoe_iron.png" />
-    <None Remove="Assets\Definitions\Items\shovel_iron.png" />
-    <None Remove="Assets\Definitions\Items\sword_iron.png" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="dotVariant" Version="0.3.1" />
     <PackageReference Include="engenious" Version="0.5.1.4-alpha" />
     <PackageReference Include="engenious.UI" Version="0.5.1.1-alpha" />
   </ItemGroup>
+
   <ItemGroup>
-    <EmbeddedResource Include="Assets\Definitions\Blocks\dirt.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\brick_grey.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\brick_red.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cactus_inside.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cactus_side.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cactus_top.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cotton_blue.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cotton_green.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cotton_red.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\cotton_tan.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\dirt_grass.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\dirt_snow.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\grass_top.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\gravel.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\greystone.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\ice.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\leaves.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\leaves_orange.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\birch_wood_side.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\birch_wood_top.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\planks.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\planks_red.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\redstone.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\axe_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\bucket.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\chest.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\hammer_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\hoe_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\pick_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\sand.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\snow.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\stone.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\water.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\wood_side.png" />
-    <EmbeddedResource Include="Assets\Definitions\Blocks\wood_top.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\shovel_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\sword_iron.png" />
-    <EmbeddedResource Include="Assets\Definitions\Items\wauziegg.png" />
+    <EmbeddedResource Include="Assets\**" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\OctoAwesome.Client.UI\OctoAwesome.Client.UI.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/OctoAwesome/OctoAwesome.Client.UI/Controls/CrosshairControl.cs
+++ b/OctoAwesome/OctoAwesome.Client.UI/Controls/CrosshairControl.cs
@@ -17,12 +17,34 @@ namespace OctoAwesome.Client.UI.Controls
 
         AssetComponent assets;
 
+        private static int crosshairSize = 8;
+
+        /// <summary>
+        /// Die Größe des Crosshair
+        /// </summary>
+        public static int CrosshairSize
+        {
+            get => crosshairSize;
+            set => crosshairSize = Math.Clamp(value, 0, MaxSize);
+        }
+
+        /// <summary>
+        /// Die Farbe des Crosshair
+        /// </summary>
+        public static Color CrosshairColor { get; set; }
+
+
+        /// <summary>
+        /// Maximum Größe des Crosshair
+        /// </summary>
+        public const int MaxSize = 100;
+
+
         public CrosshairControl(BaseScreenComponent manager, AssetComponent asset) : base(manager)
         {
             assets = asset;
 
             Transparency = 0.5f;
-            Color = Color.White;
 
             Texture = assets.LoadTexture(GetType(), "octocross");
         }
@@ -31,6 +53,9 @@ namespace OctoAwesome.Client.UI.Controls
         {
             if (!assets.Ready)
                 return;
+
+            Color = CrosshairColor = base.ScreenManager.se;
+            Width = Height = CrosshairSize;
 
             batch.Draw(Texture, contentArea, Color * Transparency);
         }

--- a/OctoAwesome/OctoAwesome.Client.UI/Controls/GroupBox.cs
+++ b/OctoAwesome/OctoAwesome.Client.UI/Controls/GroupBox.cs
@@ -1,0 +1,116 @@
+﻿using engenious.UI;
+using engenious.UI.Controls;
+
+namespace OctoAwesome.Client.UI.Controls
+{
+    public class GroupBox : Control
+    {
+        private Brush borderColor = SolidColorBrush.Black;
+
+        public Brush BorderColor
+        {
+            get => borderColor;
+            set
+            {
+                if (outerPanel is not null)
+                    outerPanel.Background = value;
+                borderColor = value;
+            }
+        }
+
+        private Border border = Border.All(2);
+
+        public Border Border
+        {
+            get => border;
+            set
+            {
+                if (outerPanel is not null)
+                    outerPanel.Padding = value;
+                border = value;
+            }
+        }
+        private Orientation orientation = Orientation.Vertical;
+
+        public Orientation Orientation
+        {
+            get => orientation;
+            set
+            {
+                if (contentPanel is not null)
+                    contentPanel.Orientation = value;
+                orientation = value;
+            }
+        }
+
+        private string headline;
+
+        public string Headline
+        {
+            get => headline;
+            set
+            {
+                if (headlineLabel is not null)
+                {
+                    headlineLabel.Height = string.IsNullOrEmpty(value) ? 0 : null;
+                    headlineLabel.Text = value;
+                }
+                headline = value;
+            }
+        }
+
+        public new ControlCollection Children => contentPanel.Controls;
+
+        private readonly StackPanel outerPanel;
+        private readonly StackPanel innerPanel;
+        private readonly StackPanel contentPanel;
+        private readonly StackPanel headlinePanel;
+        private readonly Label headlineLabel;
+
+        public GroupBox(BaseScreenComponent manager, string style = "") : base(manager, style)
+        {
+            outerPanel = new(manager)
+            {
+                Padding = Border,
+                Background = BorderColor
+            };
+
+            innerPanel = new StackPanel(manager)
+            {
+                Orientation = Orientation.Vertical,
+                Background = SolidColorBrush.White,
+            };
+
+            headlinePanel = new(manager)
+            {
+                Orientation= Orientation.Vertical,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+
+            headlineLabel = new Label(manager)
+            {
+                Text = Headline,
+                Height = 0,
+            };
+
+            headlinePanel.Controls.Add(headlineLabel);
+            headlinePanel.Controls.Add(new Line(manager)
+            {
+                Color = SolidColorBrush.Black,
+            });
+            innerPanel.Controls.Add(headlinePanel);
+
+            contentPanel = new StackPanel(manager)
+            {
+                Orientation = Orientation,
+                Background = SolidColorBrush.White,
+                HorizontalAlignment= HorizontalAlignment.Stretch,
+            };
+
+            innerPanel.Controls.Add(contentPanel);
+
+            outerPanel.Controls.Add(innerPanel);
+            base.Children.Add(outerPanel);
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome.Client.UI/Controls/Line.cs
+++ b/OctoAwesome/OctoAwesome.Client.UI/Controls/Line.cs
@@ -1,0 +1,15 @@
+﻿using engenious.UI;
+
+namespace OctoAwesome.Client.UI.Controls
+{
+    public class Line : Control
+    {
+        public Brush Color { get => Background; set => Background = value; }
+
+        public Line(BaseScreenComponent manager, string style = "") : base(manager, style)
+        {
+            Height = 1;
+            HorizontalAlignment = HorizontalAlignment.Stretch;
+        }
+    }
+}

--- a/OctoAwesome/OctoAwesome.Client.UI/OctoAwesome.Client.UI.csproj
+++ b/OctoAwesome/OctoAwesome.Client.UI/OctoAwesome.Client.UI.csproj
@@ -6,9 +6,6 @@
 
   <ItemGroup>
     <None Remove="Assets\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Assets\**" />
   </ItemGroup>
 

--- a/OctoAwesome/OctoAwesome.Client/Control/OptionsOptionControl.cs
+++ b/OctoAwesome/OctoAwesome.Client/Control/OptionsOptionControl.cs
@@ -3,10 +3,17 @@ using engenious.UI;
 using engenious.UI.Controls;
 using OctoAwesome.Client.Screens;
 using OctoAwesome.Client.UI.Components;
+using OctoAwesome.Client.UI.Controls;
 using System;
 
 namespace OctoAwesome.Client.Controls
 {
+    record ComboBoxColor(Color Color)
+    {
+        public static implicit operator ComboBoxColor(Color color) => new(color);
+        public static implicit operator Color(ComboBoxColor comboBoxColor) => comboBoxColor.Color;
+    }
+
     internal sealed class OptionsOptionControl : Panel
     {
         private readonly Label rangeTitle;
@@ -29,6 +36,65 @@ namespace OctoAwesome.Client.Controls
                 Width = 650
             };
             Controls.Add(settingsStack);
+
+            #region Crosshair settings
+            var crosshairGroupBox = new GroupBox(manager)
+            {
+                Headline = "Crosshair settings",
+            };
+
+            settingsStack.Controls.Add(crosshairGroupBox);
+
+            var crosshairCurrentLabel = new Label(manager)
+            {
+                Text = $"Size:{CrosshairControl.CrosshairSize}"
+            };
+            crosshairGroupBox.Children.Add(crosshairCurrentLabel);
+            var crosshairSizeSlider = new Slider(manager)
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Height = 20,
+                Range = CrosshairControl.MaxSize,
+                Value = CrosshairControl.CrosshairSize
+            };
+
+            crosshairSizeSlider.ValueChanged += crosshairValue =>
+            {
+                crosshairCurrentLabel.Text = $"Size:{crosshairValue}";
+                CrosshairControl.CrosshairSize = crosshairValue;
+            };
+            crosshairGroupBox.Children.Add(crosshairSizeSlider);
+
+            crosshairGroupBox.Children.Add(new Label(manager)
+            {
+                Text = "Color"
+            });
+
+            var crosshairColor = new Combobox<ComboBoxColor>(manager)
+            {
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+            crosshairGroupBox.Children.Add(crosshairColor);
+            crosshairColor.TemplateGenerator = item =>
+            {
+                return new Panel(manager)
+                {
+                    Background = new SolidColorBrush(item),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Stretch,
+                    Height = 20,
+                };
+            };
+
+            crosshairColor.SelectedItemChanged += (s, e) => CrosshairControl.CrosshairColor = e.NewItem;
+
+            crosshairColor.Items.Add(Color.White);
+            crosshairColor.Items.Add(Color.Black);
+            crosshairColor.Items.Add(Color.Red);
+            crosshairColor.Items.Add(Color.Green);
+            crosshairColor.Items.Add(Color.Blue);
+            crosshairColor.SelectedItem = CrosshairControl.CrosshairColor;
+            #endregion
 
             //////////////////////Viewrange//////////////////////
             string viewrange = settings.Get<string>("Viewrange");

--- a/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
+++ b/OctoAwesome/OctoAwesome.Client/OctoAwesome.Client.csproj
@@ -4,37 +4,35 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>warnings</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <ApplicationIcon>octoawesome.ico</ApplicationIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
   <ItemGroup>
-    <EngeniousContentReference Include="Content\Content.ecp" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Content\simple.fx" />
-    <Content Include="Content\BoldFont.png" />
-    <Content Include="Content\GameFont.png" />
-    <Content Include="Content\HeadlineFont.png" />
-    <Content Include="Content\Hud.png" />
+    <Content Include="Content\**" />
     <Content Include="Copyright.txt" />
+
     <None Include="de\LoadingScreenQuotes.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+
     <Content Include="FEEDBACK.txt" />
     <Content Include="octoawesome.ico" />
     <Content Include="TODO.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Content\engenious.CreatedContent.Content.dll" />
+    <Compile Remove="Content\bin\**" />
+    <Compile Remove="Content\obj\**" />
+    <EmbeddedResource Remove="Content\bin\**" />
+    <EmbeddedResource Remove="Content\obj\**" />
+    <None Remove="Content\bin\**" />
+    <None Remove="Content\obj\**" />
+    <Content Remove="Content\bin\**" />
+    <Content Remove="Content\obj\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,14 +46,18 @@
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
   </ItemGroup>
+
   <ItemGroup>
+    <ProjectReference Include="..\OctoAwesome.Basics\OctoAwesome.Basics.csproj" />
     <ProjectReference Include="..\OctoAwesome.Client.UI\OctoAwesome.Client.UI.csproj" />
     <ProjectReference Include="..\OctoAwesome.Network\OctoAwesome.Network.csproj" />
     <ProjectReference Include="..\OctoAwesome.Runtime\OctoAwesome.Runtime.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <EngeniousContentReference Include="Content\Content.ecp" />
     <Reference Include="engenious.CreatedContent.Content">
-      <HintPath>F:\Repos\octoawesome\OctoAwesome\OctoAwesome.Client\Content\engenious.CreatedContent.Content.dll</HintPath>
+      <HintPath>Content\engenious.CreatedContent.Content.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/OctoAwesome/OctoAwesome.Client/Screens/BaseScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/BaseScreen.cs
@@ -21,9 +21,12 @@ namespace OctoAwesome.Client.Screens
         {
             if (Manager.CanGoBack)
             {
-                BackButton = new TextButton(Manager, UI.Languages.OctoClient.Back);
-                BackButton.VerticalAlignment = VerticalAlignment.Top;
-                BackButton.HorizontalAlignment = HorizontalAlignment.Left;
+                BackButton = new TextButton(Manager, UI.Languages.OctoClient.Back)
+                {
+                    VerticalAlignment = VerticalAlignment.Top,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    TabStop = false,
+                };
                 BackButton.LeftMouseClick += (s, e) =>
                 {
                     Manager.NavigateBack();
@@ -41,7 +44,7 @@ namespace OctoAwesome.Client.Screens
 
         protected override void OnKeyPress(KeyEventArgs args)
         {
-            if (Manager.CanGoBack && args.Key == Keys.Back)
+            if (Manager.CanGoBack && (args.Key == Keys.Back || args.Key == Keys.Escape))
             {
                 args.Handled = true;
                 Manager.NavigateBack();
@@ -53,7 +56,7 @@ namespace OctoAwesome.Client.Screens
         protected void AddLabeledControl(Grid grid, string name, Control c)
         {
             grid.Rows.Add(new RowDefinition() { ResizeMode = ResizeMode.Auto });
-            grid.AddControl(new Label(Manager) { Text = name }, 0, grid.Rows.Count - 1);
+            grid.AddControl(new Label(Manager) { Text = name, TabStop = false }, 0, grid.Rows.Count - 1);
             grid.AddControl(c, 1, grid.Rows.Count - 1);
             grid.Rows.Add(new RowDefinition() { ResizeMode = ResizeMode.Fixed, Height = 10 });
         }

--- a/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
+++ b/OctoAwesome/OctoAwesome.Client/Screens/GameScreen.cs
@@ -91,8 +91,6 @@ namespace OctoAwesome.Client.Screens
             crosshair = new CrosshairControl(manager, assets);
             crosshair.HorizontalAlignment = HorizontalAlignment.Center;
             crosshair.VerticalAlignment = VerticalAlignment.Center;
-            crosshair.Width = 8;
-            crosshair.Height = 8;
             Controls.Add(crosshair);
 
             Title = UI.Languages.OctoClient.Game;

--- a/OctoAwesome/OctoAwesome.Community/OctoAwesome.Community.csproj
+++ b/OctoAwesome/OctoAwesome.Community/OctoAwesome.Community.csproj
@@ -6,34 +6,8 @@
 
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
-    <Content Include="Resources\2YearsPack\OctoAwesome\Client\Components\background.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\2YearsPack\OctoAwesome\Client\Components\background_new.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\2YearsPack\packinfo.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\PartyResources\OctoAwesome\Basics\Definitions\Blocks\dirt.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\PartyResources\packinfo.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\TomTexturePack\OctoAwesome\Basics\Definitions\Blocks\dirt.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\TomTexturePack\packinfo.xml">
+    <Content Include="Resources\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
+++ b/OctoAwesome/OctoAwesome.Database/OctoAwesome.Database.csproj
@@ -5,14 +5,6 @@
     <Nullable>warnings</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>

--- a/OctoAwesome/OctoAwesome.Docs/OctoAwesome.Docs.csproj
+++ b/OctoAwesome/OctoAwesome.Docs/OctoAwesome.Docs.csproj
@@ -12,14 +12,6 @@
     <Content Include="template\conceptual.extension.js" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="docfx.console" Version="2.56.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/OctoAwesome/OctoAwesome.GameServer/OctoAwesome.GameServer.csproj
+++ b/OctoAwesome/OctoAwesome.GameServer/OctoAwesome.GameServer.csproj
@@ -12,14 +12,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\OctoAwesome.Network\OctoAwesome.Network.csproj" />
     <ProjectReference Include="..\OctoAwesome.Runtime\OctoAwesome.Runtime.csproj" />

--- a/OctoAwesome/OctoAwesome.Network/OctoAwesome.Network.csproj
+++ b/OctoAwesome/OctoAwesome.Network/OctoAwesome.Network.csproj
@@ -21,14 +21,6 @@
     <ProjectReference Include="..\OctoAwesome.Runtime\OctoAwesome.Runtime.csproj" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
-  </PropertyGroup>
-
   <!-- Fix adapted from https://jaylee.org/archive/2019/03/31/using-span-of-t-in-xamarin-cross-targeted-projects.html
     Remove System.Memory/System.Buffers if mono is installed at default location
 -->

--- a/OctoAwesome/OctoAwesome/OctoAwesome.csproj
+++ b/OctoAwesome/OctoAwesome/OctoAwesome.csproj
@@ -3,17 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>warnings</Nullable>
-
-    <DocumentationFile>..\bin\Release\OctoAwesome.xml</DocumentationFile>
-
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\bin\Debug\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\bin\Release\</OutputPath>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- GroupBox Control hinzugefügt
- Line Control hinzugefügt (mal eine einfache Linie)
- Erlaubt das drücken von Esc wenn man im Menü zurück navigieren möchte(ich fande Backspace sehr unintuitiv)
- Beim Erstellen eines neuen Universums wird nun die Textbox für den Universums-Namen fokusiert, mit Tab kann man nun in die Seed Textbox springen
- Fügt Optionen hinzu mit denen man sofort(ohne das Spiel neuzustarten, oder das Universum neuzuladen), die Eigenschaften des Crosshair Controls abändern kann
  - Man kann nun die Größe einstellen (Ich habe es nie richtig gesehen)
  - Man kann nun die Farbe aus 5 verschiedenen Optionen auswählen (engenious hat kein Colorpicker Control)
  - Ich weiß nicht genau, wie das bisherige Speichern der Optionen funktioniert hat und habe es auch nicht verstanden. Daher sind die Crosshair Einstellungen nur temporär bis zum Spiel Neustart
### basiert auf #288 